### PR TITLE
FIX type naming

### DIFF
--- a/KakapoExample/KakapoExample.xcodeproj/project.pbxproj
+++ b/KakapoExample/KakapoExample.xcodeproj/project.pbxproj
@@ -184,8 +184,8 @@
 		DE93529C1CAAF21300AD534C /* KakapoTests */ = {
 			isa = PBXGroup;
 			children = (
-				E3280B431CB02E2B00102333 /* checkUrlTest.swift */,
 				DE93529F1CAAF21300AD534C /* Info.plist */,
+				E3280B431CB02E2B00102333 /* checkUrlTest.swift */,
 				8B0B70BD1CAE69090039CC03 /* KakapoDBTests.swift */,
 				8BF0A17B1CB073E6008C5C16 /* KakapoServerTests.swift */,
 			);

--- a/Source/KakapoDB.swift
+++ b/Source/KakapoDB.swift
@@ -1,6 +1,6 @@
 //
 //  KakapoDB.swift
-//  KakapoExample
+//  Kakapo
 //
 //  Created by Joan Romano on 31/03/16.
 //  Copyright © 2016 devlucky. All rights reserved.

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -1,6 +1,6 @@
 //
 //  KakapoServer.swift
-//  KakapoExample
+//  Kakapo
 //
 //  Created by Joan Romano on 31/03/16.
 //  Copyright © 2016 devlucky. All rights reserved.
@@ -10,19 +10,18 @@ import Foundation
 
 class KakapoServer: NSURLProtocol {
     
-    typealias KakapoLookupObject = (method: KakapoHTTPMethod,
-                                    handler: (request: KakapoRequest) -> ())
+    typealias Route = (method: HTTPMethod, handler: (request: Request) -> ())
     
-    enum KakapoHTTPMethod: String {
+    enum HTTPMethod: String {
         case GET, POST, PUT, DELETE
     }
     
-    struct KakapoRequest {
+    struct Request {
         let urlString: String
         let info: URLInfo
     }
     
-    private static var routes: [String : KakapoLookupObject] = [:]
+    private static var routes: [String : Route] = [:]
     
     class func enable() {
         NSURLProtocol.registerClass(self)
@@ -58,7 +57,7 @@ class KakapoServer: NSURLProtocol {
         
         for (key, object) in KakapoServer.routes {
             if let info = parseUrl(key, requestURL: requestString) {
-                object.handler(request: KakapoRequest(urlString: requestString, info: info))
+                object.handler(request: Request(urlString: requestString, info: info))
             }
         }
         
@@ -74,19 +73,19 @@ class KakapoServer: NSURLProtocol {
         
     }
     
-    static func get(urlString: String, handler: (request: KakapoRequest) -> ()) {
+    static func get(urlString: String, handler: (request: Request) -> ()) {
         KakapoServer.routes[urlString] = (.GET, handler)
     }
     
-    static func post(urlString: String, handler: (request: KakapoRequest) -> ()) {
+    static func post(urlString: String, handler: (request: Request) -> ()) {
         KakapoServer.routes[urlString] = (.POST, handler)
     }
     
-    static func del(urlString: String, handler: (request: KakapoRequest) -> ()) {
+    static func del(urlString: String, handler: (request: Request) -> ()) {
         KakapoServer.routes[urlString] = (.DELETE, handler)
     }
     
-    static func put(urlString: String, handler: (request: KakapoRequest) -> ()) {
+    static func put(urlString: String, handler: (request: Request) -> ()) {
         KakapoServer.routes[urlString] = (.PUT, handler)
     }
     

--- a/Source/NSURL+Kakapo.swift
+++ b/Source/NSURL+Kakapo.swift
@@ -1,6 +1,6 @@
 //
 //  NSURL+Kakapo.swift
-//  KakapoExample
+//  Kakapo
 //
 //  Created by Joan Romano on 31/03/16.
 //  Copyright © 2016 devlucky. All rights reserved.

--- a/Source/String+Kakapo.swift
+++ b/Source/String+Kakapo.swift
@@ -1,6 +1,6 @@
 //
 //  String+Kakapo.swift
-//  KakapoExample
+//  Kakapo
 //
 //  Created by Joan Romano on 31/03/16.
 //  Copyright © 2016 devlucky. All rights reserved.


### PR DESCRIPTION
Proposing different naming, we should avoid prefixing as it's useless. I would maybe just leave it for too generic things like DB. But HTTPMethod should be okay especially because it is an enum inside a class (`ClassName.HTTPMethod`)

@joanromano @zzarcon overall very cool job, I have some changes in mind for the DB but that will come after. Awesome. ![partyparrot](http://cultofthepartyparrot.com/parrots/parrot.gif)
