### PR TITLE
Serializer Refactor

### DIFF
--- a/KakapoExample/KakapoExample.xcodeproj/project.pbxproj
+++ b/KakapoExample/KakapoExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		33210B9DB2ED3249862E6A78 /* Pods_KakapoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3180C29CBC1D50E0769D5D15 /* Pods_KakapoTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DE0A9E691CCD33E40030253B /* XCTestCase+CustomAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A9E681CCD33E40030253B /* XCTestCase+CustomAssertions.swift */; };
 		DE0A9E6B1CCD3DDE0030253B /* CustomAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A9E6A1CCD3DDE0030253B /* CustomAssertions.swift */; };
+		DE0A9E761CD4005F0030253B /* PropertyPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A9E751CD4005F0030253B /* PropertyPolicyTests.swift */; };
 		DE33B8951CB47148007F6161 /* KakapoDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE33B8911CB47148007F6161 /* KakapoDB.swift */; };
 		DE33B8961CB47148007F6161 /* KakapoServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE33B8921CB47148007F6161 /* KakapoServer.swift */; };
 		DE33B8971CB47148007F6161 /* NSURL+Kakapo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE33B8931CB47148007F6161 /* NSURL+Kakapo.swift */; };
@@ -75,6 +76,7 @@
 		B3F83AF0069920CA81FFC28B /* Pods-KakapoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KakapoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KakapoTests/Pods-KakapoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		DE0A9E681CCD33E40030253B /* XCTestCase+CustomAssertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+CustomAssertions.swift"; sourceTree = "<group>"; };
 		DE0A9E6A1CCD3DDE0030253B /* CustomAssertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomAssertions.swift; sourceTree = "<group>"; };
+		DE0A9E751CD4005F0030253B /* PropertyPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyPolicyTests.swift; sourceTree = "<group>"; };
 		DE33B8911CB47148007F6161 /* KakapoDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KakapoDB.swift; sourceTree = "<group>"; };
 		DE33B8921CB47148007F6161 /* KakapoServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KakapoServer.swift; sourceTree = "<group>"; };
 		DE33B8931CB47148007F6161 /* NSURL+Kakapo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSURL+Kakapo.swift"; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				DE33B89A1CB4717B007F6161 /* KakapoDBTests.swift */,
 				DE33B89B1CB4717B007F6161 /* KakapoServerTests.swift */,
 				DE53E2431CAD719D00CD1AC0 /* SerializerTests.swift */,
+				DE0A9E751CD4005F0030253B /* PropertyPolicyTests.swift */,
 				DE93529F1CAAF21300AD534C /* Info.plist */,
 				DE0A9E681CCD33E40030253B /* XCTestCase+CustomAssertions.swift */,
 			);
@@ -444,6 +447,7 @@
 			files = (
 				DE33B89C1CB4717B007F6161 /* checkUrlTest.swift in Sources */,
 				DE33B89D1CB4717B007F6161 /* KakapoDBTests.swift in Sources */,
+				DE0A9E761CD4005F0030253B /* PropertyPolicyTests.swift in Sources */,
 				DE0A9E691CCD33E40030253B /* XCTestCase+CustomAssertions.swift in Sources */,
 				DE53E2441CAD719D00CD1AC0 /* SerializerTests.swift in Sources */,
 				DE33B89E1CB4717B007F6161 /* KakapoServerTests.swift in Sources */,

--- a/KakapoExample/KakapoTests/PropertyPolicyTests.swift
+++ b/KakapoExample/KakapoTests/PropertyPolicyTests.swift
@@ -1,0 +1,62 @@
+//
+//  PropertyPolicyTests.swift
+//  KakapoExample
+//
+//  Created by Alex Manzella on 29/04/16.
+//  Copyright © 2016 devlucky. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import Kakapo
+
+private struct Test<T>: Serializable {
+    let value: PropertyPolicy<T>
+}
+
+private struct User: Serializable {
+    let name: String
+}
+
+class IgnorableNilPropertySpec: QuickSpec {
+    override func spec() {
+        
+        describe("Property policy serialization") {
+            it("is not serialized if nil") {
+                let serialized = Test(value: PropertyPolicy<Int>.None).serialize() as! [String: AnyObject]
+                expect(serialized.count).to(be(0))
+            }
+            
+            it("is serialized if not nil") {
+                let serialized = Test(value: PropertyPolicy.Some(object: 1)).serialize() as! [String: AnyObject]
+                expect(serialized.count).to(be(1))
+                let value = serialized["value"] as? Int
+                expect(value).to(be(1))
+            }
+            
+            it("return NSNull when .Null") {
+                let serialized = Test(value: PropertyPolicy<Int>.Null).serialize() as! [String: AnyObject]
+                expect(serialized.count).to(be(1))
+                let value = serialized["value"] as? NSNull
+                expect(value).toNot(beNil())
+            }
+            
+            it("recursively serialize the object if needed") {
+                let serialized = Test(value: PropertyPolicy.Some(object: User(name: "Alex"))).serialize() as! [String: AnyObject]
+                expect(serialized.count).to(be(1))
+                let value = serialized["value"] as? [String: AnyObject]
+                expect(value?["name"] as? String).to(equal("Alex"))
+            }
+            
+            it("recursively serialize PropertyPolicy") {
+                let policy = PropertyPolicy.Some(object: 1)
+                let policyOfPolicy = PropertyPolicy.Some(object: policy)
+                let serialized = Test(value: policyOfPolicy).serialize() as! [String: AnyObject]
+                expect(serialized.count).to(be(1))
+                let value = serialized["value"] as? Int
+                expect(value).to(be(1))
+            }
+        }
+    }
+}

--- a/KakapoExample/KakapoTests/SerializerTests.swift
+++ b/KakapoExample/KakapoTests/SerializerTests.swift
@@ -11,22 +11,6 @@ import Quick
 import Nimble
 @testable import Kakapo
 
-class IgnorableNilPropertySpec: QuickSpec {
-    override func spec() {
-        describe("Nil ignorable property") {
-            it("is nil") {
-                let ignorableProperty = IgnorableNilProperty<Int>(nil)
-                expect(ignorableProperty.shouldSerialize).to(beFalse())
-            }
-            
-            it("is not nil") {
-                let ignorableProperty = IgnorableNilProperty(1)
-                expect(ignorableProperty.shouldSerialize).to(beTrue())
-            }
-        }
-    }
-}
-
 struct MaybeEmpty<T>: Serializable {
     let value: T
     
@@ -137,35 +121,6 @@ class SerializeSpec: QuickSpec {
             }
         }
         
-        describe("Property policy serialization") { 
-            it("is not serialized if nil") {
-                let empty = MaybeEmpty(IgnorableNilProperty<Int>(nil))
-                let serialized = empty.serialize() as! [String: AnyObject]
-                expect(serialized.count).to(be(0))
-            }
-            
-            it("is serialized if not nil") {
-                let notEmpty = MaybeEmpty(IgnorableNilProperty(1))
-                let serialized = notEmpty.serialize() as! [String: AnyObject]
-                let value = serialized["value"] as? Int
-                expect(value).to(be(1))
-            }
-            
-            it("recursively serialize the object if needed") {
-                let notEmpty = MaybeEmpty(IgnorableNilProperty(user))
-                let serialized = notEmpty.serialize() as! [String: AnyObject]
-                let value = serialized["value"] as? [String: AnyObject]
-                expect(value?["name"] as? String).to(equal("Alex"))
-            }
-
-            it("recursively serialize IgnorableNilProperties") {
-                let notEmpty = MaybeEmpty(IgnorableNilProperty(IgnorableNilProperty(1)))
-                let serialized = notEmpty.serialize() as! [String: AnyObject]
-                let value = serialized["value"] as? Int
-                expect(value).to(be(1))
-            }
-        }
-        
         describe("Optional property serialization") {
 
             it("should serialize the object if it is an entry point") {
@@ -177,13 +132,14 @@ class SerializeSpec: QuickSpec {
                 let nilInt: Int? = nil
                 let optional = MaybeEmpty(nilInt)
                 let serialized = optional.serialize() as! [String: AnyObject]
-                expect(serialized["value"] as? NSNull).to(be(NSNull()))
+                expect(serialized["value"]).to(beNil())
+                expect(serialized.count).to(equal(0))
             }
             
             it("serialize an optional") {
                 let optional = MaybeEmpty(Optional.Some(1))
                 let serialized = optional.serialize() as! [String: AnyObject] as? [String: Int]
-                expect(serialized?["value"]).to(be(1))
+                expect(serialized?["value"]).to(equal(1))
             }
             
             it("recursively serialize the value") {

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -28,7 +28,7 @@ public struct Response: CustomSerializable {
         self.headerFields = headerFields
     }
     
-    public func customSerialize() -> AnyObject {
+    public func customSerialize() -> AnyObject? {
         return body.serialize()
     }
 }

--- a/Source/PropertyPolicy.swift
+++ b/Source/PropertyPolicy.swift
@@ -9,51 +9,14 @@
 import Foundation
 
 /**
- *  A *"type-erased"* protocol that should only be used internally as constraint for `PropertyPolicy` (concrete protocol with associatedtype). **See `PropertyPolicy`**
- */
-public protocol _PropertyPolicy: CustomSerializable {
-    var _object: Any { get }
-    var shouldSerialize: Bool { get }
-}
-
-/**
- *  `PropertyPolicy` is a Simple serializable object that can be used to wrap your `Serializable` Objects' properties to add specific behaviors to the property. Concrete implementation can manipulate the object hold by the property policy to achieve specific results. **See `IgnorableNilProperty`**
- */
-public protocol PropertyPolicy: _PropertyPolicy {
-    associatedtype T
-    
-    /// The object that will be serialized when shouldSerialize return true. Use specific type or Any for multiple types. Make sure it's an elegible `Serializable` or Property list object. **See `Serializable`**
-    var object: T? { get }
-    // Indicated if the property should be serialized or ignored
-    var shouldSerialize: Bool { get }
-}
-
-extension PropertyPolicy {
-    // Fake type erasure in _PropertyPolicy
-    public var _object: Any {
-        get {
-            return object
-        }
-    }
-}
-
-/**
- *  A `PropertyPolicy` that ignores nil value for optional properties. By default nil is converted to `NSNull`; wrap your property into this policy to avoid this.
+ `PropertyPolicy` is an enum similar to `Optional` but with an additional case `.Null`. It's only purpose is to be serialized in 3 different ways to cover all possible behaviors of an Optional property.
  
- ```
-    let myNilIgnorableProperty: IgnorableNilProperty<Int>
- ```
- 
- serializes the object when not nil and ignores it when nil.
+ - None:     Same behavior of `Optional.None`, the property is not included in the JSON
+ - Null:     `Null` when serialized is `NSNull` that will result as a `null` property in the JSON
+ - Some:     Serialize the associated object
  */
-public struct IgnorableNilProperty<T>: PropertyPolicy {
-    public let object: T?
-    
-    init(_ object: T?) {
-        self.object = object
-    }
-    
-    public var shouldSerialize: Bool {
-        return object != nil
-    }
+public enum PropertyPolicy<T>: CustomSerializable {
+    case None
+    case Null
+    case Some(object: T)
 }

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -24,11 +24,11 @@ public protocol CustomSerializable: Serializable {
      
      - returns: You should return either another `Serializable` object (also `Array` or `Dictionary`) containing other Serializable objects or property list types that can be serialized into json (primitive types).
      */
-    func customSerialize() -> AnyObject
+    func customSerialize() -> AnyObject?
 }
 
 extension Serializable {
-    func serialize() -> AnyObject {
+    func serialize() -> AnyObject? {
         if let object = self as? CustomSerializable {
             return object.customSerialize()
         }
@@ -36,7 +36,8 @@ extension Serializable {
     }
     
     func toData() -> NSData? {
-        let object = serialize()
+        guard let object = serialize() else { return nil }
+        
         if !NSJSONSerialization.isValidJSONObject(object) {
             return nil
         }
@@ -46,10 +47,12 @@ extension Serializable {
 
 extension Array: CustomSerializable {
     // Array is serialized by creating an Array of its objects serialized
-    public func customSerialize() -> AnyObject {
+    public func customSerialize() -> AnyObject? {
         var array = [AnyObject]()
         for obj in self {
-            array.append(serializeObject(obj))
+            if let serialized = serializeObject(obj) {
+                array.append(serialized)
+            }
         }
         return array
     }
@@ -57,41 +60,51 @@ extension Array: CustomSerializable {
 
 extension Dictionary: CustomSerializable {
     // Dictionary is serialized by creating a Dictionary with the same keys and values serialized
-    public func customSerialize() -> AnyObject {
+    public func customSerialize() -> AnyObject? {
         var dictionary = [String: AnyObject]()
         for (key, value) in self {
             assert(key is String, "key must be a String to be serialized to JSON")
-            dictionary[key as! String] = serializeObject(value)
+            if let serialized = serializeObject(value) {
+                dictionary[key as! String] = serialized
+            }
         }
         return dictionary
     }
 }
 
 extension Optional: CustomSerializable {
-    // Optional serializes its inner object or NSNull if nil
-    public func customSerialize() -> AnyObject {
+    // Optional serializes its inner object or nil if nil
+    public func customSerialize() -> AnyObject? {
         switch self {
         case let .Some(value):
             return serializeObject(value)
         default:
-            return NSNull()
+            return nil
         }
     }
 }
 
-extension _PropertyPolicy {
-    // _PropertyPolicy serializes its inner object
-    public func customSerialize() -> AnyObject {
-        return serializeObject(_object)
+extension PropertyPolicy {
+    // PropertyPolicy serializes as nil when `.None`, as `NSNull` when `.Null` or serialize the object for `.Some`
+    public func customSerialize() -> AnyObject? {
+        switch self {
+        case .None:
+            return nil
+        case .Null:
+            return NSNull()
+        case let .Some(value):
+            return serializeObject(value)
+        }
     }
 }
 
-private func serializeObject(value: Any) -> AnyObject {
+private func serializeObject(value: Any) -> AnyObject? {
     if let value = value as? Serializable {
         return value.serialize()
     } else {
-        // At this point an object must be an AnyObject and probably also a property list object otherwise the json will fail later.
-        return value as! AnyObject
+        // At this point an object must be nil or an AnyObject and probably also a property list object otherwise the json will fail later.
+//        assert(value == nil || value as! AnyObject)
+        return value as? AnyObject
     }
 }
 
@@ -109,14 +122,8 @@ private func serialize(object: Serializable) -> AnyObject {
     var dictionary = [String: AnyObject]()
     let mirror = Mirror(reflecting: object)
     for child in mirror.children {
-        if let label = child.label {
-            if let value = child.value as? _PropertyPolicy {
-                if value.shouldSerialize {
-                    dictionary[label] = serializeObject(value._object)
-                }
-            } else {
-                dictionary[label] = serializeObject(child.value)
-            }
+        if let label = child.label, let value = serializeObject(child.value) {
+            dictionary[label] = value
         }
     }
     

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -102,8 +102,8 @@ private func serializeObject(value: Any) -> AnyObject? {
     if let value = value as? Serializable {
         return value.serialize()
     } else {
-        // At this point an object must be nil or an AnyObject and probably also a property list object otherwise the json will fail later.
-//        assert(value == nil || value as! AnyObject)
+        // At this point an object must be an AnyObject and probably also a property list object otherwise the json will fail later.
+        assert((value as? AnyObject) != nil)
         return value as? AnyObject
     }
 }

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -101,11 +101,11 @@ extension PropertyPolicy {
 private func serializeObject(value: Any) -> AnyObject? {
     if let value = value as? Serializable {
         return value.serialize()
-    } else {
-        // At this point an object must be an AnyObject and probably also a property list object otherwise the json will fail later.
-        assert((value as? AnyObject) != nil)
-        return value as? AnyObject
     }
+    
+    // At this point an object must be an AnyObject and probably also a property list object otherwise the json will fail later.
+    assert((value as? AnyObject) != nil)
+    return value as? AnyObject
 }
 
 /**


### PR DESCRIPTION
Closes #51 
Closes #50 
Serialize now returns an optional and eliminates the need for special handling of Property Policy and Optional.
Serialized Optional won't be included by default when nil (previously was NSNull)
PropertyPolicy is now much simpler, just an enum that should cover all use cases and doesn't need special handling because it leverages the power of CustomSerializable
