### PR TITLE
Add SerializationTransformer

### DIFF
--- a/Kakapo.xcodeproj/project.pbxproj
+++ b/Kakapo.xcodeproj/project.pbxproj
@@ -17,6 +17,13 @@
 		8BE0FC871D172EC900FE706A /* JSONAPILinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE0FC831D172EC900FE706A /* JSONAPILinks.swift */; };
 		AC9577F342F6730725CC9D72 /* Pods_Kakapo_tvOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C67882333142806D5CF9A918 /* Pods_Kakapo_tvOSTests.framework */; };
 		D5363674ABF8735A0A1368BD /* Pods_Kakapo_macOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABE4F11D5A141DB87CD81023 /* Pods_Kakapo_macOSTests.framework */; };
+		DE3950A51D216334008DCF43 /* SerializationTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A41D216334008DCF43 /* SerializationTransformer.swift */; };
+		DE3950A61D216334008DCF43 /* SerializationTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A41D216334008DCF43 /* SerializationTransformer.swift */; };
+		DE3950A71D216334008DCF43 /* SerializationTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A41D216334008DCF43 /* SerializationTransformer.swift */; };
+		DE3950A81D216334008DCF43 /* SerializationTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A41D216334008DCF43 /* SerializationTransformer.swift */; };
+		DE3950AA1D216C77008DCF43 /* SerializationTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A91D216C77008DCF43 /* SerializationTransformerTests.swift */; };
+		DE3950AB1D216C77008DCF43 /* SerializationTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A91D216C77008DCF43 /* SerializationTransformerTests.swift */; };
+		DE3950AC1D216C77008DCF43 /* SerializationTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3950A91D216C77008DCF43 /* SerializationTransformerTests.swift */; };
 		DE76E1311D0DC62B009721A4 /* Kakapo.h in Headers */ = {isa = PBXBuildFile; fileRef = DE76E0FA1D0DC37E009721A4 /* Kakapo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE76E1411D0DC640009721A4 /* Kakapo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE76E1371D0DC640009721A4 /* Kakapo.framework */; };
 		DE76E15D1D0DC65B009721A4 /* Kakapo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE76E1531D0DC65B009721A4 /* Kakapo.framework */; };
@@ -122,6 +129,8 @@
 		ABE4F11D5A141DB87CD81023 /* Pods_Kakapo_macOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Kakapo_macOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C67882333142806D5CF9A918 /* Pods_Kakapo_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Kakapo_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9E9EAD776E83C0F5785A0DB /* Pods-Kakapo macOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Kakapo macOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Kakapo macOSTests/Pods-Kakapo macOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DE3950A41D216334008DCF43 /* SerializationTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SerializationTransformer.swift; sourceTree = "<group>"; };
+		DE3950A91D216C77008DCF43 /* SerializationTransformerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SerializationTransformerTests.swift; sourceTree = "<group>"; };
 		DE76E0F91D0DC37E009721A4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DE76E0FA1D0DC37E009721A4 /* Kakapo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Kakapo.h; sourceTree = "<group>"; };
 		DE76E0FE1D0DC38B009721A4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -287,6 +296,7 @@
 				DE76E1B31D0DC857009721A4 /* PropertyPolicyTests.swift */,
 				DE76E1B41D0DC857009721A4 /* RouterTests.swift */,
 				DE76E1B51D0DC857009721A4 /* SerializerTests.swift */,
+				DE3950A91D216C77008DCF43 /* SerializationTransformerTests.swift */,
 				DE76E1B61D0DC857009721A4 /* URLDecomposerTests.swift */,
 				DE76E1B71D0DC857009721A4 /* XCTestCase+CustomAssertions.swift */,
 			);
@@ -306,6 +316,7 @@
 				DE76E1061D0DC395009721A4 /* Router.swift */,
 				DE76E1071D0DC395009721A4 /* Serializer.swift */,
 				DE76E1081D0DC395009721A4 /* URLDecomposer.swift */,
+				DE3950A41D216334008DCF43 /* SerializationTransformer.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -746,6 +757,7 @@
 				DE82027B1D20068A00552FEC /* JSONAPIError.swift in Sources */,
 				DE76E1991D0DC755009721A4 /* NSURLRequest+FixCopy.swift in Sources */,
 				DE76E1A71D0DC762009721A4 /* CustomAssertions.swift in Sources */,
+				DE3950A61D216334008DCF43 /* SerializationTransformer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -764,6 +776,7 @@
 				DE82027C1D20068A00552FEC /* JSONAPIError.swift in Sources */,
 				DE76E1911D0DC755009721A4 /* NSURLRequest+FixCopy.swift in Sources */,
 				DE76E1A81D0DC762009721A4 /* CustomAssertions.swift in Sources */,
+				DE3950A71D216334008DCF43 /* SerializationTransformer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -780,6 +793,7 @@
 				DE8202801D200C9000552FEC /* JSONAPIErrorTests.swift in Sources */,
 				DE76E1CE1D0DC857009721A4 /* XCTestCase+CustomAssertions.swift in Sources */,
 				DE76E1C21D0DC857009721A4 /* PropertyPolicyTests.swift in Sources */,
+				DE3950AB1D216C77008DCF43 /* SerializationTransformerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -798,6 +812,7 @@
 				DE82027D1D20068A00552FEC /* JSONAPIError.swift in Sources */,
 				DE76E1891D0DC754009721A4 /* NSURLRequest+FixCopy.swift in Sources */,
 				DE76E1A91D0DC763009721A4 /* CustomAssertions.swift in Sources */,
+				DE3950A81D216334008DCF43 /* SerializationTransformer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -814,6 +829,7 @@
 				DE8202811D200C9000552FEC /* JSONAPIErrorTests.swift in Sources */,
 				DE76E1CF1D0DC857009721A4 /* XCTestCase+CustomAssertions.swift in Sources */,
 				DE76E1C31D0DC857009721A4 /* PropertyPolicyTests.swift in Sources */,
+				DE3950AC1D216C77008DCF43 /* SerializationTransformerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -832,6 +848,7 @@
 				DE82027A1D20068A00552FEC /* JSONAPIError.swift in Sources */,
 				DE76E1A11D0DC756009721A4 /* NSURLRequest+FixCopy.swift in Sources */,
 				DE76E1A61D0DC761009721A4 /* CustomAssertions.swift in Sources */,
+				DE3950A51D216334008DCF43 /* SerializationTransformer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -848,6 +865,7 @@
 				DE82027F1D200C9000552FEC /* JSONAPIErrorTests.swift in Sources */,
 				DE76E1CD1D0DC857009721A4 /* XCTestCase+CustomAssertions.swift in Sources */,
 				DE76E1C11D0DC857009721A4 /* PropertyPolicyTests.swift in Sources */,
+				DE3950AA1D216C77008DCF43 /* SerializationTransformerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/JSONAPILinks.swift
+++ b/Source/JSONAPILinks.swift
@@ -24,11 +24,11 @@ public enum JSONAPILink: CustomSerializable {
     case Simple(value: String)
     case Object(href: String, meta: Serializable)
     
-    public func customSerialize() -> AnyObject? {
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
         switch self {
         case let Object(href, meta):
             var serializedObject: [String: AnyObject] = ["href" : href]
-            serializedObject["meta"] = meta.serialize()
+            serializedObject["meta"] = meta.serialize(keyTransformer)
             
             return serializedObject
         case let Simple(value):

--- a/Source/JSONAPISerializer.swift
+++ b/Source/JSONAPISerializer.swift
@@ -15,19 +15,21 @@ public protocol JSONAPISerializable {
      
      - parameter includeRelationships: Defines if it should include the `relationships` field
      - parameter includeAttributes:    Defines if it should include the `attributes` field
+     - parameter keyTransformer:       The keyTransformer to be used, if not nil, to transform the keys of the json
      
      - returns: Return an object representing the `data` field conforming to JSON API, for `JSONAPIEntity` boxes the return type will be used to fill the `relationships` field otherwise, when nil, the box will be serialized normally and used for the `attributes` field.
      */
-    func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool) -> AnyObject?
+    func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool, keyTransformer: KeyTransformer?) -> AnyObject?
     
     /**
      Creates the `included` field by aggregating and unifying the attributes of the relationships recursively
      
      - parameter includeChildren: Include relationships of relationships recursively, by default `JSONAPISerializer` won't include children
+     - parameter keyTransformer:  The keyTransformer to be used, if not nil, to transform the keys of the json
 
      - returns: An array of included relationsips or nil if no relationsips are incldued.
      */
-    func includedRelationships(includeChildren: Bool) -> [AnyObject]?
+    func includedRelationships(includeChildren: Bool, keyTransformer: KeyTransformer?) -> [AnyObject]?
 }
 
 /**
@@ -67,18 +69,37 @@ public protocol JSONAPIEntity: CustomSerializable, JSONAPISerializable {
     var id: String { get }
 }
 
+private typealias JSONAPIConvertible = protocol<JSONAPISerializable, Serializable>
+
+/// A wrapper struct that handles the serialization of the JSON API data field
+private struct JSONAPIDataWrapper: CustomSerializable {
+    let object: JSONAPIConvertible
+    
+    private func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
+        return object.data(includeRelationships: true, includeAttributes: true, keyTransformer: keyTransformer)
+    }
+}
+
+/// A wrapper struct that handles the serialization of the JSON API include field
+private struct JSONAPIIncludedWrapper: CustomSerializable {
+    let object: JSONAPIConvertible
+    let includeChildren: Bool
+    
+    private func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
+        return object.includedRelationships(includeChildren, keyTransformer: nil)?.unifiedIncludedRelationships()
+    }
+}
+
 /**
  *  An object responsible to serialize a `JSONAPIEntity` or an array of `JSONAPIEntity` conforming to JSON API
  */
 public struct JSONAPISerializer<T: JSONAPIEntity>: Serializable {
-    
-    private typealias JSONAPIConvertible = protocol<JSONAPISerializable, Serializable>
 
     /// Top level [`data`](http://jsonapi.org/format/#document-top-level) member: the document’s “primary data”
-    private let data: JSONAPIConvertible
+    private let data: JSONAPIDataWrapper
 
     /// Top level `included` member: an array of resource objects that are related to the primary data and/or each other (“included resources”).
-    private let included: [AnyObject]?
+    private let included: JSONAPIIncludedWrapper
 
     /// Top level [`links`](http://jsonapi.org/format/#document-links) member: a links object related to the primary data.
     private let links: [String: JSONAPILink]?
@@ -86,14 +107,14 @@ public struct JSONAPISerializer<T: JSONAPIEntity>: Serializable {
     /// Top level [`meta`](http://jsonapi.org/format/#document-meta) member: used to include non-standard meta-information.
     private let meta: Serializable?
 
-    private typealias JSONAPISerializerInit = (data: JSONAPIConvertible, links: [String: JSONAPILink]?, meta: Serializable?, included: [AnyObject]?)
+    private typealias JSONAPISerializerInit = (data: JSONAPIDataWrapper, links: [String: JSONAPILink]?, meta: Serializable?, included: JSONAPIIncludedWrapper)
     
     private static func commonInit(object: JSONAPIConvertible, topLevelLinks: [String: JSONAPILink]?, meta: Serializable?, includeChildren: Bool) -> JSONAPISerializerInit {
         return (
-            data: object,
+            data: JSONAPIDataWrapper(object: object),
             links: topLevelLinks,
             meta: meta,
-            included: object.includedRelationships(includeChildren)?.unifiedIncludedRelationships()
+            included: JSONAPIIncludedWrapper(object: object, includeChildren: includeChildren)
         )
     }
     
@@ -132,13 +153,13 @@ extension Array: JSONAPISerializable {
     
     // MARK: JSONAPISerializable
     
-    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool) -> AnyObject? {
-        return Element.self is JSONAPISerializable.Type ? flatMap { ($0 as? JSONAPISerializable)?.data(includeRelationships: includeRelationships, includeAttributes: includeAttributes) } : nil
+    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool, keyTransformer: KeyTransformer?) -> AnyObject? {
+        return Element.self is JSONAPISerializable.Type ? flatMap { ($0 as? JSONAPISerializable)?.data(includeRelationships: includeRelationships, includeAttributes: includeAttributes, keyTransformer: keyTransformer) } : nil
     }
     
-    public func includedRelationships(includeChildren: Bool) -> [AnyObject]? {
+    public func includedRelationships(includeChildren: Bool, keyTransformer: KeyTransformer?) -> [AnyObject]? {
         guard Element.self is JSONAPISerializable.Type else { return nil }
-        return flatMap { ($0 as? JSONAPISerializable)?.includedRelationships(includeChildren) }.flatMap { $0 }
+        return flatMap { ($0 as? JSONAPISerializable)?.includedRelationships(includeChildren, keyTransformer: keyTransformer) }.flatMap { $0 }
     }
     
     private func unifiedIncludedRelationships() -> [AnyObject] {
@@ -175,7 +196,7 @@ extension PropertyPolicy: JSONAPISerializable {
     
     // MARK: JSONAPISerializable
     
-    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool) -> AnyObject? {
+    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool, keyTransformer: KeyTransformer?) -> AnyObject? {
         guard Wrapped.self is JSONAPISerializable.Type else {
             return nil
         }
@@ -183,7 +204,7 @@ extension PropertyPolicy: JSONAPISerializable {
         switch self {
         case let .Some(value):
             if let value = value as? JSONAPISerializable {
-                return value.data(includeRelationships: includeRelationships, includeAttributes: includeAttributes)
+                return value.data(includeRelationships: includeRelationships, includeAttributes: includeAttributes, keyTransformer: keyTransformer)
             }
             
         case .Null:
@@ -195,8 +216,8 @@ extension PropertyPolicy: JSONAPISerializable {
         return nil
     }
     
-    public func includedRelationships(includeChildren: Bool) -> [AnyObject]? {
-        return wrapped?.includedRelationships(includeChildren)
+    public func includedRelationships(includeChildren: Bool, keyTransformer: KeyTransformer?) -> [AnyObject]? {
+        return wrapped?.includedRelationships(includeChildren, keyTransformer: keyTransformer)
     }
 }
 
@@ -217,12 +238,12 @@ extension Optional: JSONAPISerializable {
     
     // MARK: JSONAPISerializable
     
-    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool) -> AnyObject? {
-        return wrapped?.data(includeRelationships: includeRelationships, includeAttributes: includeAttributes)
+    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool, keyTransformer: KeyTransformer?) -> AnyObject? {
+        return wrapped?.data(includeRelationships: includeRelationships, includeAttributes: includeAttributes, keyTransformer: keyTransformer)
     }
     
-    public func includedRelationships(includeChildren: Bool) -> [AnyObject]? {
-        return wrapped?.includedRelationships(includeChildren)
+    public func includedRelationships(includeChildren: Bool, keyTransformer: KeyTransformer?) -> [AnyObject]? {
+        return wrapped?.includedRelationships(includeChildren, keyTransformer: keyTransformer)
     }
 }
 
@@ -236,13 +257,13 @@ public extension JSONAPIEntity {
     
     // MARK: CustomSerializable
 
-    public func customSerialize() -> AnyObject? {
-        return data(includeRelationships: true, includeAttributes: true)!
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
+        return data(includeRelationships: true, includeAttributes: true, keyTransformer: keyTransformer)!
     }
     
     // MARK: JSONAPISerializable
 
-    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool) -> AnyObject? {
+    public func data(includeRelationships includeRelationships: Bool, includeAttributes: Bool, keyTransformer: KeyTransformer?) -> AnyObject? {
         var data = [String: AnyObject]()
         
         data["id"] = id
@@ -259,27 +280,27 @@ public extension JSONAPIEntity {
         
         if let linkedEntity = self as? JSONAPILinkedEntity,
                entityLinks = linkedEntity.links where entityLinks.count > 0 {
-            data["links"] = entityLinks.serialize()
+            data["links"] = entityLinks.serialize(keyTransformer)
         }
         
         let excludedKeys: Set<String> = ["id", "links", "topLinks"]
         
         for child in mirror.children {
             if let label = child.label {
-                if let value = child.value as? JSONAPISerializable, let data = value.data(includeRelationships: false, includeAttributes: false) {
+                if let value = child.value as? JSONAPISerializable, let data = value.data(includeRelationships: false, includeAttributes: false, keyTransformer: keyTransformer) {
                     if includeRelationships {
                         var relationship: [String: AnyObject] = ["data" : data]
                         
                         if let linkedEntity = self as? JSONAPILinkedEntity,
                                relationshipsLinks = linkedEntity.relationshipsLinks?[label] where relationshipsLinks.count > 0 {
-                            relationship["links"] = relationshipsLinks.serialize()
+                            relationship["links"] = relationshipsLinks.serialize(keyTransformer)
                         }
                         
                         relationships[label] = relationship
                     }
                 } else if includeAttributes && !excludedKeys.contains(label)  {
                     if let value = child.value as? Serializable {
-                        attributes[label] = value.serialize()
+                        attributes[label] = value.serialize(keyTransformer)
                     } else {
                         assert(child.value is AnyObject)
                         attributes[label] = child.value as? AnyObject
@@ -299,12 +320,12 @@ public extension JSONAPIEntity {
         return data
     }
     
-    public func includedRelationships(includeChildren: Bool) -> [AnyObject]? {
+    public func includedRelationships(includeChildren: Bool, keyTransformer: KeyTransformer?) -> [AnyObject]? {
         let mirror = Mirror(reflecting: self)
         let includedRelationships = mirror.children.flatMap { (label, value) -> [AnyObject] in
             
             guard let value = value as? JSONAPISerializable,
-                let include = value.data(includeRelationships: false, includeAttributes: true) else {
+                let include = value.data(includeRelationships: false, includeAttributes: true, keyTransformer: keyTransformer) else {
                 return []
             }
             
@@ -316,7 +337,7 @@ public extension JSONAPIEntity {
                 return [include]
             }()
             
-            if includeChildren, let childRelationships = value.includedRelationships(includeChildren) {
+            if includeChildren, let childRelationships = value.includedRelationships(includeChildren, keyTransformer: keyTransformer) {
                 return childRelationships + relationships
             }
             

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -50,8 +50,8 @@ public protocol ResponseFieldsProvider: CustomSerializable {
 
 extension ResponseFieldsProvider {
     
-    public func customSerialize() -> AnyObject? {
-        return body.serialize()
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
+        return body.serialize(keyTransformer)
     }
 }
 

--- a/Source/SerializationTransformer.swift
+++ b/Source/SerializationTransformer.swift
@@ -1,0 +1,96 @@
+//
+//  SerializationTransformer.swift
+//  Kakapo
+//
+//  Created by Alex Manzella on 27/06/16.
+//  Copyright © 2016 devlucky. All rights reserved.
+//
+
+import Foundation
+
+/// A closure that given a String as input output the transformed String, used to transform keys of the json
+public typealias KeyTransformer = (key: String) -> String
+
+/**
+ *  A protocol that special `Serializable` objects can adopt to transform other `Serializable` objects.
+ *  At the moment only key transforms are supported, see `SnakecaseTransformer` for a concrete implementations
+ */
+public protocol SerializationTransformer: CustomSerializable {
+    
+    /// The wrapped object type
+    associatedtype Wrapped: Serializable
+    
+    /// The wrapped `Serializable` object
+    var wrapped: Wrapped { get }
+    
+    /**
+     A function that given a String as input output the transformed String, used to transform keys of the json
+     
+     - parameter key: The key to transform
+     
+     - returns: Should return the transformed key, for example an `UppercaseTransformer` would return the uppercase key.
+     */
+    func transform(key key: String) -> String
+}
+
+extension SerializationTransformer {
+    
+    /**
+     `SerializationTransformer`by default serialize it's object using the given keyTransformer (if any) and it's own key transformer.
+     Its own keyTransformer must always be used before the one provided by the callers, so UppercaseTransformer(LowercaseTransformer(object)) would result in uppercase keys.
+     
+     - returns: The serialized wrapped object with transformed keys.
+     */
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
+        return wrapped.serialize { (string) in
+            let transformed = self.transform(key: string)
+            return keyTransformer?(key: transformed) ?? transformed
+        }
+    }
+}
+
+/**
+ *  A `SerializableTransformer` that transform CamelCase json keys in snake_case keys.
+ 
+    Example:
+    ```
+    struct User {
+       let userName: String
+    }
+ 
+    let result = SnakecaseTransformer(wrapped: User(userName: "Alex")) // -> {"user_name": "Alex"}
+ 
+    ```
+ */
+public struct SnakecaseTransformer<Wrapped: Serializable>: SerializationTransformer {
+    
+    public let wrapped: Wrapped
+    
+    public func transform(key key: String) -> String {
+        return key.snakecaseString()
+    }
+}
+
+private extension String {
+    
+    /// Converts a camelCase string into a snake_case one.
+    func snakecaseString() -> String {
+        var string = String()
+        let charactersView = self.characters
+        let startIndex = charactersView.startIndex
+        let endIndex = charactersView.count - 1
+        
+        for (idx, c) in charactersView.reverse().enumerate() {
+            let char = String(c)
+            let lowercased = char.lowercaseString
+            let isUppercase = char != lowercased
+            
+            string.insert(Character(lowercased), atIndex: startIndex)
+            
+            if isUppercase && idx != endIndex {
+                string.insert("_", atIndex: startIndex)
+            }
+        }
+        return string
+    }
+}

--- a/Source/SerializationTransformer.swift
+++ b/Source/SerializationTransformer.swift
@@ -12,8 +12,9 @@ import Foundation
 public typealias KeyTransformer = (key: String) -> String
 
 /**
- *  A protocol that special `Serializable` objects can adopt to transform other `Serializable` objects.
- *  At the moment only key transforms are supported, see `SnakecaseTransformer` for a concrete implementations
+ *  A protocol that special `Serializable` objects can adopt to transform other **wrapped** `Serializable` objects.
+ *  At the moment this protocol only provide the key transformation functionality.
+ *  See `SnakecaseTransformer` for a concrete implementation.
  */
 public protocol SerializationTransformer: CustomSerializable {
     

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -66,8 +66,9 @@ extension Dictionary: CustomSerializable {
         var dictionary = [String: AnyObject]()
         for (key, value) in self {
             assert(key is String, "key must be a String to be serialized to JSON")
-            if let serialized = serializeObject(value, keyTransformer: keyTransformer) {
-                dictionary[key as! String] = serialized
+            if let serialized = serializeObject(value, keyTransformer: keyTransformer), let key = key as? String {
+                let transformedKey = keyTransformer?(key: key) ?? key
+                dictionary[transformedKey] = serialized
             }
         }
         return dictionary

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -22,7 +22,7 @@ public protocol CustomSerializable: Serializable {
     /**
      Serialize by returning a valid object
 
-     - parameter keyTransformer: An Optional closure to transform the keys, for custom serializations the implementation must take care of transforming the key
+     - parameter keyTransformer: An Optional closure to transform the keys, for custom serializations the implementation must take care of transforming the keys. This closure, for example, is not nil when a `Serializable` object is wrapped in a `SerializationTransformer`, the wrapper object will expect `CustomSerializable` object to correctly handle the key transformation (see `SerializationTransformer`)
 
      - returns: You should return either another `Serializable` object (also `Array` or `Dictionary`) containing other Serializable objects or property list types that can be serialized into json (primitive types).
      */

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -21,18 +21,20 @@ public protocol Serializable {
 public protocol CustomSerializable: Serializable {
     /**
      Serialize by returning a valid object
-     
+
+     - parameter keyTransformer: An Optional closure to transform the keys, for custom serializations the implementation must take care of transforming the key
+
      - returns: You should return either another `Serializable` object (also `Array` or `Dictionary`) containing other Serializable objects or property list types that can be serialized into json (primitive types).
      */
-    func customSerialize() -> AnyObject?
+    func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject?
 }
 
 extension Serializable {
-    func serialize() -> AnyObject? {
+    func serialize(keyTransformer: KeyTransformer? = nil) -> AnyObject? {
         if let object = self as? CustomSerializable {
-            return object.customSerialize()
+            return object.customSerialize(keyTransformer)
         }
-        return Kakapo.serialize(self)
+        return Kakapo.serialize(self, keyTransformer: keyTransformer)
     }
     
     func toData() -> NSData? {
@@ -47,10 +49,10 @@ extension Serializable {
 
 extension Array: CustomSerializable {
     // Array is serialized by creating an Array of its objects serialized
-    public func customSerialize() -> AnyObject? {
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
         var array = [AnyObject]()
         for obj in self {
-            if let serialized = serializeObject(obj) {
+            if let serialized = serializeObject(obj, keyTransformer: keyTransformer) {
                 array.append(serialized)
             }
         }
@@ -60,11 +62,11 @@ extension Array: CustomSerializable {
 
 extension Dictionary: CustomSerializable {
     // Dictionary is serialized by creating a Dictionary with the same keys and values serialized
-    public func customSerialize() -> AnyObject? {
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
         var dictionary = [String: AnyObject]()
         for (key, value) in self {
             assert(key is String, "key must be a String to be serialized to JSON")
-            if let serialized = serializeObject(value) {
+            if let serialized = serializeObject(value, keyTransformer: keyTransformer) {
                 dictionary[key as! String] = serialized
             }
         }
@@ -74,10 +76,10 @@ extension Dictionary: CustomSerializable {
 
 extension Optional: CustomSerializable {
     // Optional serializes its inner object or nil if nil
-    public func customSerialize() -> AnyObject? {
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
         switch self {
         case let .Some(value):
-            return serializeObject(value)
+            return serializeObject(value, keyTransformer: keyTransformer)
         default:
             return nil
         }
@@ -86,21 +88,21 @@ extension Optional: CustomSerializable {
 
 extension PropertyPolicy {
     // PropertyPolicy serializes as nil when `.None`, as `NSNull` when `.Null` or serialize the object for `.Some`
-    public func customSerialize() -> AnyObject? {
+    public func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
         switch self {
         case .None:
             return nil
         case .Null:
             return NSNull()
         case let .Some(value):
-            return serializeObject(value)
+            return serializeObject(value, keyTransformer: keyTransformer)
         }
     }
 }
 
-private func serializeObject(value: Any) -> AnyObject? {
+private func serializeObject(value: Any, keyTransformer: KeyTransformer?) -> AnyObject? {
     if let value = value as? Serializable {
-        return value.serialize()
+        return value.serialize(keyTransformer)
     }
     
     // At this point an object must be an AnyObject and probably also a property list object otherwise the json will fail later.
@@ -113,17 +115,19 @@ private func serializeObject(value: Any) -> AnyObject? {
  It recursively serialize the objects until it reaches primitive types, or fails if not possible. The final objects must be primitive types (property list compatible) or the serialization will fail because it can't be represented by JSON. This means that a `Serializable` objects must make sure that their properties are all `Serializable` or primitive types.
  
  - parameter object: A Serializable object, not a `CustomSerializable`
+ - parameter keyTransformer: The keyTransformer to be used, if not nil, to transform the keys of the json
  
  - returns: A serialized object that may be convered to JSON, usually Array or Dictionary
  */
-private func serialize(object: Serializable) -> AnyObject {
+private func serialize(object: Serializable, keyTransformer: KeyTransformer?) -> AnyObject {
     assert(!(object is CustomSerializable))
 
     var dictionary = [String: AnyObject]()
     let mirror = Mirror(reflecting: object)
     for child in mirror.children {
-        if let label = child.label, let value = serializeObject(child.value) {
-            dictionary[label] = value
+        if let label = child.label, let value = serializeObject(child.value, keyTransformer: keyTransformer) {
+            let key = keyTransformer?(key: label) ?? label
+            dictionary[key] = value
         }
     }
     

--- a/Tests/JSONAPITests.swift
+++ b/Tests/JSONAPITests.swift
@@ -58,7 +58,7 @@ class JSONAPISpec: QuickSpec {
         let id: String
         let title: String
         
-        func customSerialize() -> AnyObject? {
+        func customSerialize(keyTransformer: KeyTransformer?) -> AnyObject? {
             return ["foo": "bar"]
         }
     }

--- a/Tests/SerializationTransformerTests.swift
+++ b/Tests/SerializationTransformerTests.swift
@@ -1,0 +1,137 @@
+//
+//  SerializationTransformerTests.swift
+//  Kakapo
+//
+//  Created by Alex Manzella on 27/06/16.
+//  Copyright © 2016 devlucky. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import Kakapo
+
+struct UppercaseTransformer<Wrapped: Serializable>: SerializationTransformer {
+    
+    let wrapped: Wrapped
+    
+    func transform(key key: String) -> String {
+        return key.uppercaseString
+    }
+}
+
+struct LowercaseFirstCharacterTransformer<Wrapped: Serializable>: SerializationTransformer {
+    
+    let wrapped: Wrapped
+    
+    func transform(key key: String) -> String {
+        let characters = key.characters
+        let first = String(characters.prefix(1)).lowercaseString
+        let other = String(characters.dropFirst())
+        return first + other
+    }
+}
+
+class SerializationTransformerSpec: QuickSpec {
+    
+    struct User: Serializable {
+        let name: String
+    }
+    
+    struct Friend: Serializable {
+        let friends: [User]
+        
+        init(friends: [User]) {
+            self.friends = friends
+        }
+    }
+    
+    struct Snake: Serializable {
+        let theSnakeCamelFriend: String
+    }
+    
+    override func spec() {
+        
+        describe("Serialization Transformers") {
+            it("transforms the keys of a serialized object") {
+                let user = User(name: "Alex")
+                let friend = Friend(friends: [user])
+                let serialized = UppercaseTransformer(wrapped: friend).serialize() as! [String: AnyObject]
+                let friends = serialized["FRIENDS"] as? [AnyObject]
+                let first = friends?.first as? [String: AnyObject]
+                expect(first?.keys.first).to(equal("NAME"))
+            }
+            
+            it("should apply transformations in the right order") {
+                let user = User(name: "Alex")
+                let friend = Friend(friends: [user])
+                
+                do {
+                    let serialized = LowercaseFirstCharacterTransformer(wrapped: UppercaseTransformer(wrapped: friend)).serialize() as! [String: AnyObject]
+                    let friends = serialized["fRIENDS"] as? [AnyObject]
+                    let first = friends?.first as? [String: AnyObject]
+                    expect(first?.keys.first).to(equal("nAME"))
+                }
+                
+                do {
+                    let serialized = UppercaseTransformer(wrapped: LowercaseFirstCharacterTransformer(wrapped: friend)).serialize() as! [String: AnyObject]
+                    let friends = serialized["FRIENDS"] as? [AnyObject]
+                    let first = friends?.first as? [String: AnyObject]
+                    expect(first?.keys.first).to(equal("NAME"))
+                }
+            }
+        }
+        
+        describe("Snake Case Transformer") {
+            let user = User(name: "Alex")
+            let transformer = SnakecaseTransformer(wrapped: user)
+            
+            it("should prefix uppercase characters with _") {
+                expect(transformer.transform(key: "userNameOfALuckyUser")).to(equal("user_name_of_a_lucky_user"))
+            }
+            
+            it("should lowercase all characters") {
+                expect(transformer.transform(key: "aLuckyUser")).to(equal("a_lucky_user"))
+            }
+            
+            it("should not prepend _ to the first character when is uppercase") {
+                expect(transformer.transform(key: "ALuckyUser")).to(equal("a_lucky_user"))
+            }
+            
+            it("should not append _ to the last character when is uppercase") {
+                expect(transformer.transform(key: "ALuckyUseR")).to(equal("a_lucky_use_r"))
+            }
+            
+            it("should not touch non-camelCase strings") {
+                expect(transformer.transform(key: "something")).to(equal("something"))
+            }
+            
+            it("should transform correctly the wrapped object's keys") {
+                let snake = Snake(theSnakeCamelFriend: "abc")
+                let serialized = SnakecaseTransformer(wrapped: snake).serialize() as? [String: AnyObject]
+                expect(serialized?.keys.first).to(equal("the_snake_camel_friend"))
+            }
+        }
+        
+        // CustomSerializable objects need to handle key transformer themselves
+        // every CustomSerializable in Kakapo must be tested here.
+        describe("CustomSerializable needs to handle (or forward) key transformer themselves") {
+            
+            context("JSON API") {
+                // TODO:
+            }
+            
+            context("Optional") {
+                // TODO:
+            }
+            
+            context("PropertyPolicy") {
+                // TODO:
+            }
+            
+            context("JSON API") {
+                // TODO:
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #48 

@joanromano let me know what you think, I took a different approach than in feature/keyTransformer , while the other one didn't require touching the Implementation of Serializable/CustomSerializable and didn't require `CustomSerializable` to take care of the keyTransformer, this approach is much cleaner and easier to handle, other than performant 
