### PR TITLE
Use String as id for Storable

### DIFF
--- a/Source/KakapoDB.swift
+++ b/Source/KakapoDB.swift
@@ -14,9 +14,10 @@ import Foundation
  This is a base protocol and it's only used internally, for your objects you should check `Storable` instead.
  */
 public protocol _Storable {
+    // TODO: document
     // TODO: default to String and create a protocol that as an Int id with default implementation. Because String is not always convertible to Int but Int can always be converted to String.
-    var id: Int { get }
-    init(id: Int, db: KakapoDB)
+    var id: String { get }
+    init(id: String, db: KakapoDB)
 }
 
 /**
@@ -118,7 +119,7 @@ public final class KakapoDB {
      
      - returns: The new inserted Storable object
      */
-    public func insert<T: Storable>(handler: (Int) -> T) -> T {
+    public func insert<T: Storable>(handler: (String) -> T) -> T {
         let id = barrierSync {
             return self.uuid()
         }
@@ -208,13 +209,13 @@ public final class KakapoDB {
      
      - returns: An optional thay may (or not) contain the found Storable object
      */
-    public func find<T: Storable>(_: T.Type, id: Int) -> T? {
+    public func find<T: Storable>(_: T.Type, id: String) -> T? {
         return filter(T.self) { $0.id == id }.first
     }
     
-    private func uuid() -> Int {
+    private func uuid() -> String {
         _uuid += 1
-        return _uuid
+        return String(_uuid)
     }
     
     private func lookup<T: Storable>(_: T.Type) -> ArrayBox<_Storable> {

--- a/Source/KakapoDB.swift
+++ b/Source/KakapoDB.swift
@@ -14,9 +14,17 @@ import Foundation
  This is a base protocol and it's only used internally, for your objects you should check `Storable` instead.
  */
 public protocol _Storable {
-    // TODO: document
-    // TODO: default to String and create a protocol that as an Int id with default implementation. Because String is not always convertible to Int but Int can always be converted to String.
+    /// The unique identifier provided by `KakapoDB`, objects shouldn't generate ids themselves. `KakapoDB` generate `Int` ids converted to String for better compatibilities with standards like JSONAPI, in case you need `Int` ids is safe to ssume that the conversion will always succeeed.
     var id: String { get }
+    
+    /**
+     An initializer that is used by `KakapoDB` to create objects to be stored in the db
+     
+     - parameter id: The unique identifier provided by `KakapoDB`, objects shouldn't generate ids themselves. `KakapoDB` generate `Int` ids converted to String for better compatibilities with standards like JSONAPI, in case you need `Int` ids is safe to ssume that the conversion will always succeeed.
+     - parameter db: The db that is creating the object, can be used  to generate other `Storable` objects, for example relationsips of the object by using `db.create(MyRelationshipType)`.
+     
+     - returns: A configured object stored in the db.
+     */
     init(id: String, db: KakapoDB)
 }
 

--- a/Tests/KakapoDBTests.swift
+++ b/Tests/KakapoDBTests.swift
@@ -8,22 +8,19 @@
 
 import Quick
 import Nimble
-//import Fakery
 @testable import Kakapo
 
-//let faker = Faker()
-
 struct UserFactory: Storable, Serializable, Equatable {
+    let id: String
     let firstName: String
     let lastName: String
     let age: Int
-    let id: Int
     
-    init(id: Int, db: KakapoDB) {
+    init(id: String, db: KakapoDB) {
         self.init(firstName: "tmp", lastName: "tmp", age: random(), id: id)
     }
     
-    init(firstName: String, lastName: String, age: Int, id: Int) {
+    init(firstName: String, lastName: String, age: Int, id: String) {
         self.firstName = firstName
         self.lastName = lastName
         self.age = age
@@ -36,15 +33,15 @@ func ==(lhs: UserFactory, rhs: UserFactory) -> Bool {
 }
 
 struct CommentFactory: Storable {
+    let id: String
     let text: String
     let likes: Int
-    let id: Int
     
-    init(id: Int, db: KakapoDB) {
+    init(id: String, db: KakapoDB) {
         self.init(text: "tmp", likes: random(), id: id)
     }
     
-    init(text: String, likes: Int, id: Int) {
+    init(text: String, likes: Int, id: String) {
         self.text = text
         self.likes = likes
         self.id = id
@@ -79,24 +76,24 @@ class KakapoDBTests: QuickSpec {
                 })
                 
                 let userObjects = sut.findAll(UserFactory.self)
-                let user = sut.find(UserFactory.self, id: 1)
+                let user = sut.find(UserFactory.self, id: "1")
                 
                 let commentObjects = sut.findAll(CommentFactory.self)
-                let aComment = sut.find(CommentFactory.self, id: 1000)
-                let anotherComment = sut.find(CommentFactory.self, id: 1002)
+                let aComment = sut.find(CommentFactory.self, id: "1000")
+                let anotherComment = sut.find(CommentFactory.self, id: "1002")
                 
                 expect(user).toNot(beNil())
                 expect(user?.firstName).toNot(beNil())
-                expect(user?.id) == 1
+                expect(user?.id) == "1"
                 expect(userObjects.count) == 1000
                 
                 expect(aComment).toNot(beNil())
                 expect(aComment?.text).toNot(beNil())
-                expect(aComment?.id) == 1000
+                expect(aComment?.id) == "1000"
                 
                 expect(anotherComment).toNot(beNil())
                 expect(anotherComment?.text).toNot(beNil())
-                expect(anotherComment?.id) == 1002
+                expect(anotherComment?.id) == "1002"
                 
                 expect(commentObjects.count) == 5000
             }
@@ -116,19 +113,19 @@ class KakapoDBTests: QuickSpec {
             
             it("should insert a large number of elements") {
                 dispatch_apply(1000, dispatch_queue_create("queue", DISPATCH_QUEUE_CONCURRENT), { _ in
-                    sut.insert { (id) -> UserFactory in
-                        return UserFactory(firstName: "Name " + String(id), lastName: "Last Name " + String(id), age: id, id: id)
+                    sut.insert{ (id) -> (UserFactory) in
+                        return UserFactory(firstName: "Name " + id, lastName: "Last Name " + id, age: 10, id: id)
                     }
                 })
                 
                 let userObjects = sut.findAll(UserFactory.self)
-                let user = sut.find(UserFactory.self, id: 1)
+                let user = sut.find(UserFactory.self, id: "1")
                 
                 expect(user).toNot(beNil())
                 expect(user?.firstName).to(contain("Name 1"))
                 expect(user?.lastName).to(contain("Last Name 1"))
-                expect(user?.id).toNot(beNil())
-                expect(user?.age).toNot(beNil())
+                expect(user?.id).to(equal("1"))
+                expect(user?.age).to(equal(10))
                 expect(userObjects.count) == 1000
             }
         }
@@ -136,19 +133,19 @@ class KakapoDBTests: QuickSpec {
         describe("Finding and Filtering") {
             it("should return the expected object with a given id after inserting 20 objects") {
                 sut.create(UserFactory.self, number: 20)
-                let user = sut.find(UserFactory.self, id: 1)
+                let user = sut.find(UserFactory.self, id: "1")
                 
                 expect(user).toNot(beNil())
                 expect(user?.firstName).toNot(beNil())
-                expect(user?.id) == 1
+                expect(user?.id) == "1"
             }
             
             it("should return the expected object with a given id after inserting different object types") {
                 sut.create(UserFactory.self, number: 20)
                 sut.create(CommentFactory.self, number: 20)
-                let user = sut.find(UserFactory.self, id: 1)
-                let wrongComment = sut.find(CommentFactory.self, id: 2)
-                let comment = sut.find(CommentFactory.self, id: 22)
+                let user = sut.find(UserFactory.self, id: "1")
+                let wrongComment = sut.find(CommentFactory.self, id: "2")
+                let comment = sut.find(CommentFactory.self, id: "22")
                 
                 expect(user).toNot(beNil())
                 expect(wrongComment).to(beNil())
@@ -160,10 +157,10 @@ class KakapoDBTests: QuickSpec {
                     return UserFactory(firstName: "Hector", lastName: "Zarco", age:25, id: id)
                 }
                 
-                let user = sut.find(UserFactory.self, id: 0)
+                let user = sut.find(UserFactory.self, id: "0")
                 expect(user?.firstName).to(match("Hector"))
                 expect(user?.lastName).to(match("Zarco"))
-                expect(user?.id) == 0
+                expect(user?.id) == "0"
             }
             
             it("should fail a precondition when inserting invalid id") {
@@ -173,7 +170,7 @@ class KakapoDBTests: QuickSpec {
 
                 self.expectPrecondition("Tried to insert an invalid id") {
                     sut.insert { (id) -> UserFactory in
-                        return UserFactory(firstName: "Joan", lastName: "Romano", age:25, id: id-1)
+                        return UserFactory(firstName: "Joan", lastName: "Romano", age:25, id: String(Int(id)! - 1))
                     }
                 }
             }
@@ -183,14 +180,14 @@ class KakapoDBTests: QuickSpec {
                     UserFactory(firstName: "Hector", lastName: "Zarco", age:25, id: id)
                 }
                 
-                let userArray = sut.filter(UserFactory.self, includeElement: { (item) -> Bool in
-                    return item.id == 0
-                })
+                let userArray = sut.filter(UserFactory.self) { (item) -> Bool in
+                    return item.id == "0"
+                }
                 
                 expect(userArray.count) == 1
                 expect(userArray.first?.firstName).to(match("Hector"))
                 expect(userArray.first?.lastName).to(match("Zarco"))
-                expect(userArray.first?.id) == 0
+                expect(userArray.first?.id) == "0"
             }
 
             it("should return no objects for some inexisting filtering") {
@@ -210,9 +207,9 @@ class KakapoDBTests: QuickSpec {
         describe("Update") {
             it("should update a previously inserted object") {
                 sut.create(UserFactory.self, number: 20)
-                let elementToUpdate = UserFactory(firstName: "Joan", lastName: "Romano", age: 28, id: 2)
+                let elementToUpdate = UserFactory(firstName: "Joan", lastName: "Romano", age: 28, id: "2")
                 try! sut.update(elementToUpdate)
-                let updatedUserInDb = sut.find(UserFactory.self, id: 2)
+                let updatedUserInDb = sut.find(UserFactory.self, id: "2")
                 
                 expect(updatedUserInDb?.firstName).to(equal("Joan"))
                 expect(updatedUserInDb?.lastName).to(equal("Romano"))
@@ -221,9 +218,9 @@ class KakapoDBTests: QuickSpec {
             
             it("should not update an object that was never inserted") {
                 sut.create(UserFactory.self, number: 20)
-                let elementToUpdate = UserFactory(firstName: "Joan", lastName: "Romano", age: 28, id: 45)
+                let elementToUpdate = UserFactory(firstName: "Joan", lastName: "Romano", age: 28, id: "45")
                 expect{ try sut.update(elementToUpdate) }.to(throwError(errorType: KakapoDBError.self))
-                let updatedUserInDb = sut.find(UserFactory.self, id: 45)
+                let updatedUserInDb = sut.find(UserFactory.self, id: "45")
                 expect(updatedUserInDb).to(beNil())
             }
             
@@ -231,19 +228,19 @@ class KakapoDBTests: QuickSpec {
                 let anotherDB = KakapoDB()
                 sut.create(UserFactory.self, number: 20)
                 anotherDB.create(CommentFactory.self, number: 20)
-                expect{ try sut.update(anotherDB.find(CommentFactory.self, id: 5)!) }.to(throwError(errorType: KakapoDBError.self))
-                let updatedCommentInDb = sut.find(CommentFactory.self, id: 5)
+                expect{ try sut.update(anotherDB.find(CommentFactory.self, id: "5")!) }.to(throwError(errorType: KakapoDBError.self))
+                let updatedCommentInDb = sut.find(CommentFactory.self, id: "5")
                 expect(updatedCommentInDb).to(beNil())
             }
             
             it("should update same kind of objects from different databases with same id") {
                 let anotherDB = KakapoDB()
-                var theId: Int = 0
+                var theId: String!
                 sut.create(CommentFactory.self, number: 20)
-                anotherDB.insert({ (id) -> CommentFactory in
+                anotherDB.insert { (id) -> CommentFactory in
                     theId = id
                     return CommentFactory(text: "a comment", likes: 20, id: id)
-                })
+                }
                 try! sut.update(anotherDB.find(CommentFactory.self, id: theId)!)
                 let updatedComment = sut.find(CommentFactory.self, id: theId)
                 
@@ -255,7 +252,7 @@ class KakapoDBTests: QuickSpec {
         describe("Deletion") {
             it("should delete a previously inserted object") {
                 sut.create(UserFactory.self, number: 20)
-                let elementToDelete = sut.find(UserFactory.self, id: 2)!
+                let elementToDelete = sut.find(UserFactory.self, id: "2")!
                 try! sut.delete(elementToDelete)
                 let usersArray = sut.findAll(UserFactory.self)
                 
@@ -263,7 +260,7 @@ class KakapoDBTests: QuickSpec {
             }
             
             it("should delete a previously inserted object with same data representation") {
-                var theId: Int = 0
+                var theId: String!
                 sut.insert { (id) -> UserFactory in
                     theId = id
                     return UserFactory(firstName: "Joan", lastName: "Romano", age: 28, id: id)
@@ -278,14 +275,14 @@ class KakapoDBTests: QuickSpec {
             
             it("should not delete a non previously inserted object, even with same ids, since they have different data representation") {
                 sut.create(UserFactory.self, number: 20)
-                let elementToDelete = UserFactory(id: 2, db: sut)
+                let elementToDelete = UserFactory(id: "2", db: sut)
                 expect{ try sut.delete(elementToDelete) }.to(throwError(errorType: KakapoDBError.self))
                 expect(sut.findAll(UserFactory.self).count).to(equal(20))
             }
             
             it("should not delete a non previously inserted object") {
                 sut.create(UserFactory.self, number: 20)
-                let elementToDelete = UserFactory(id: 44, db: sut)
+                let elementToDelete = UserFactory(id: "44", db: sut)
                 expect{ try sut.delete(elementToDelete) }.to(throwError(errorType: KakapoDBError.self))
                 expect(sut.findAll(UserFactory.self).count).to(equal(20))
             }
@@ -294,13 +291,13 @@ class KakapoDBTests: QuickSpec {
                 let anotherDB = KakapoDB()
                 sut.create(UserFactory.self, number: 20)
                 anotherDB.create(CommentFactory.self, number: 20)
-                expect{ try sut.delete(anotherDB.find(CommentFactory.self, id: 5)!) }.to(throwError(errorType: KakapoDBError.self))
+                expect{ try sut.delete(anotherDB.find(CommentFactory.self, id: "5")!) }.to(throwError(errorType: KakapoDBError.self))
                 expect(sut.findAll(UserFactory.self).count).to(equal(20))
             }
             
             it("should delete objects from different databases with same id and data representation") {
                 let anotherDB = KakapoDB()
-                var theId: Int = 0
+                var theId: String!
                 sut.insert { (id) -> UserFactory in
                     theId = id
                     return UserFactory(firstName: "Joan", lastName: "Romano", age: 28, id: id)
@@ -445,7 +442,7 @@ class KakapoDBTests: QuickSpec {
             it("should not deadlock when synchronously updating the database from another queue during a write operation") {
                 let user = sut.insert { (id) -> UserFactory in
                     dispatch_sync(queue) {
-                        try! sut.update(UserFactory(id: 0, db: sut))
+                        try! sut.update(UserFactory(id: "0", db: sut))
                     }
                     return UserFactory(id: id, db: sut)
                 }
@@ -455,7 +452,7 @@ class KakapoDBTests: QuickSpec {
             it("should not deadlock when synchronously deleting the database from another queue during a write operation") {
                 let user = sut.insert { (id) -> UserFactory in
                     dispatch_sync(queue) {
-                        try! sut.delete(sut.find(UserFactory.self, id: 0)!)
+                        try! sut.delete(sut.find(UserFactory.self, id: "0")!)
                     }
                     return UserFactory(id: id, db: sut)
                 }
@@ -468,7 +465,7 @@ class KakapoDBTests: QuickSpec {
             
             it("should not deadlock when deleting into database during a reading operation") {
                 let result = sut.filter(UserFactory.self, includeElement: { (_) -> Bool in
-                    try! sut.delete(sut.find(UserFactory.self, id: 0)!)
+                    try! sut.delete(sut.find(UserFactory.self, id: "0")!)
                     return true
                 })
                 
@@ -480,7 +477,7 @@ class KakapoDBTests: QuickSpec {
             
             it("should not deadlock when updating into database during a reading operation") {
                 let result = sut.filter(UserFactory.self, includeElement: { (_) -> Bool in
-                    try! sut.update(UserFactory(firstName: "Alex", lastName: "Manzella", age: 30, id: 0))
+                    try! sut.update(UserFactory(firstName: "Alex", lastName: "Manzella", age: 30, id: "0"))
                     return true
                 })
                 

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -321,7 +321,7 @@ class RouterTests: QuickSpec {
                 var responseDictionary: NSDictionary? = nil
                 
                 router.get("/users/:id"){ request in
-                    return db.find(UserFactory.self, id: Int(request.components["id"]!)!)
+                    return db.find(UserFactory.self, id: request.components["id"]!)
                 }
                 
                 NSURLSession.sharedSession().dataTaskWithURL(NSURL(string: "http://www.test.com/users/2")!) { (data, response, _) in
@@ -329,7 +329,7 @@ class RouterTests: QuickSpec {
                     }.resume()
                 
                 expect(responseDictionary?["firstName"]).toNotEventually(beNil())
-                expect(responseDictionary?["id"]).toEventually(be(2))
+                expect(responseDictionary?["id"] as? String).toEventually(equal("2"))
             }
             
             it("should return 200 status code when no code specified") {
@@ -354,7 +354,7 @@ class RouterTests: QuickSpec {
                 var responseDictionary: NSDictionary? = nil
                 
                 router.get("/users/:id"){ request in
-                    return Response(statusCode: 200, body: db.find(UserFactory.self, id: Int(request.components["id"]!)!))
+                    return Response(statusCode: 200, body: db.find(UserFactory.self, id: request.components["id"]!)!)
                 }
                 
                 NSURLSession.sharedSession().dataTaskWithURL(NSURL(string: "http://www.test.com/users/2")!) { (data, response, _) in
@@ -364,7 +364,7 @@ class RouterTests: QuickSpec {
                     }.resume()
                 
                 expect(responseDictionary?["firstName"]).toNotEventually(beNil())
-                expect(responseDictionary?["id"]).toEventually(be(2))
+                expect(responseDictionary?["id"] as? String).toEventually(equal("2"))
                 expect(statusCode).toEventually(equal(200))
             }
             
@@ -440,9 +440,9 @@ class RouterTests: QuickSpec {
                 
                 expect(responseArray?.count).toEventually(equal(20))
                 expect(responseArray?.firstObject?["firstName"]).toNotEventually(beNil())
-                expect(responseArray?.firstObject?["id"]).toEventually(equal(0))
-                expect(responseArray?[14]["id"]).toEventually(equal(14))
-                expect(responseArray?.lastObject?["id"]).toEventually(equal(19))
+                expect(responseArray?.firstObject?["id"]).toEventually(equal("0"))
+                expect(responseArray?[14]["id"]).toEventually(equal("14"))
+                expect(responseArray?.lastObject?["id"]).toEventually(equal("19"))
             }
             
             it("should return nil for objects not serializable to JSON") {


### PR DESCRIPTION
Closes #26 

Rationale: 
mpow [5:24 PM]  
FYI just implemented id as String instead of Int otherwise JSONAPIEntity can't be easily Storable, the id generated by db will still be Int converted to String. This is better because Int is always convertible to string but not the other way around

 (docu missing, waiting for merge of docu PR)
