### PR TITLE
Implement NSURLProtocol.stopLoading() for delayed requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ xcuserdata
 timeline.xctimeline
 playground.xcworkspace
 
+# AppCode
+.idea
+.idea/
+
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
@@ -56,7 +60,7 @@ Carthage/Build
 
 # fastlane
 #
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md

--- a/Source/JSONAPIError.swift
+++ b/Source/JSONAPIError.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A convenince error object that conform to JSON API
+/// A convenience error object that conform to JSON API
 public struct JSONAPIError: ResponseFieldsProvider {
     
     /// An object containing references to the source of the error, optionally including any of the following members

--- a/Source/JSONAPILinks.swift
+++ b/Source/JSONAPILinks.swift
@@ -82,7 +82,7 @@ public enum JSONAPILink: CustomSerializable {
  }
  ```
  
- Appart from their own entity links, and in order to provide extra links for relationships, `User` must specify them for each relationship key:
+ Apart from their own entity links, and in order to provide extra links for relationships, `User` must specify them for each relationship key:
  
  ```swift
  let cats = [Cat(id: "33", name: "Stancho", links: nil),
@@ -111,7 +111,7 @@ public enum JSONAPILink: CustomSerializable {
 public protocol JSONAPILinkedEntity {
     /// The related links, must use link-names as keys and links as values.
     var links: [String : JSONAPILink]? { get }
-    /// The relationships links, an object containing relationsips can specify top level links for every relationship type. The object must provide a Dictionary where keys are the relationships types and values are dictionaries with link-names as keys and link as values.
+    /// The relationships links, an object containing relationships can specify top level links for every relationship type. The object must provide a Dictionary where keys are the relationships types and values are dictionaries with link-names as keys and link as values.
     var relationshipsLinks: [String : [String : JSONAPILink]]? { get }
 }
 

--- a/Source/JSONAPISerializer.swift
+++ b/Source/JSONAPISerializer.swift
@@ -257,7 +257,7 @@ public extension JSONAPIEntity {
     
     // MARK: JSONAPIEntity
 
-    /// returns the lowercased class name as string by default
+    /// returns the lower-cased class name as string by default
     static var type: String {
         return String(self).lowercaseString
     }
@@ -332,7 +332,7 @@ public extension JSONAPIEntity {
         return data
     }
     
-    /// returns the `included` relationsips field conforming to JSON API
+    /// returns the `included` relationships field conforming to JSON API
     public func includedRelationships(includeChildren: Bool, keyTransformer: KeyTransformer?) -> [AnyObject]? {
         let mirror = Mirror(reflecting: self)
         let includedRelationships = mirror.children.flatMap { (label, value) -> [AnyObject] in

--- a/Source/KakapoDB.swift
+++ b/Source/KakapoDB.swift
@@ -19,7 +19,7 @@ public protocol Storable {
      An initializer that is used by `KakapoDB` to create objects to be stored in the db
      
      - parameter id: The unique identifier provided by `KakapoDB`, objects shouldn't generate ids themselves. `KakapoDB` generate `Int` ids converted to String for better compatibilities with standards like JSONAPI, in case you need `Int` ids is safe to ssume that the conversion will always succeeed.
-     - parameter db: The db that is creating the object, can be used  to generate other `Storable` objects, for example relationsips of the object: `myRelationship = db.create(MyRelationshipType)` or `myrelationship = db.insert { MyRelationshipType(id: $0, db: db) }`. The relationsip will also recieve the `db` instance to eventually initialize its relationships.
+     - parameter db: The db that is creating the object, can be used  to generate other `Storable` objects, for example relationships of the object: `myRelationship = db.create(MyRelationshipType)` or `myrelationship = db.insert { MyRelationshipType(id: $0, db: db) }`. The relationsip will also recieve the `db` instance to eventually initialize its relationships.
      
      - returns: A configured object stored in the db.
      */
@@ -93,7 +93,7 @@ public final class KakapoDB {
     /**
      Creates and inserts Storable objects based on their default initializer
      
-     - parameter (unamed): The Storable Type to be created
+     - parameter (unnamed): The Storable Type to be created
      - parameter number: The number of elements to create, defaults to 1
      
      - returns: An array containing the new inserted Storable objects
@@ -181,7 +181,7 @@ public final class KakapoDB {
     /**
      Find all the objects in the store of a given Storable Type
      
-     - parameter (unamed): The Storable Type to be found
+     - parameter (unnamed): The Storable Type to be found
      
      - returns: An array containing the found Storable objects
      */
@@ -194,7 +194,7 @@ public final class KakapoDB {
     /**
      Filter all the objects in the store of a given Storable Type that satisfy the a given handler
      
-     - parameter (unamed): The Storable Type to be filtered
+     - parameter (unnamed): The Storable Type to be filtered
      - parameter includeElement: The predicate to satisfy the filtering
      
      - returns: An array containing the filtered Storable objects
@@ -206,10 +206,10 @@ public final class KakapoDB {
     /**
      Find the object in the store by a given id
      
-     - parameter (unamed): The Storable Type to be filtered
+     - parameter (unnamed): The Storable Type to be filtered
      - parameter id: The id to search for
      
-     - returns: An optional thay may (or not) contain the found Storable object
+     - returns: An optional, which may (or may not) contain the found Storable object
      */
     public func find<T: Storable>(_: T.Type, id: String) -> T? {
         return filter(T.self) { $0.id == id }.first

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -40,12 +40,7 @@ import Foundation
  */
 public final class KakapoServer: NSURLProtocol {
 
-    /**
-     The overall list of `Router` objects, which is know to all `KakapoServer` instances.
-     Visibility is on the `KakapoServer` class level, because `NSURLProtocol` just allows us to register
-     class elements (no instances are possible).
-     */
-    public static var routers: [Router] = []
+    private static var routers: [Router] = []
 
     /**
      `true`, if the `request` of the `KakapoServer` instance has been cancelled, otherwise `false`.
@@ -54,7 +49,7 @@ public final class KakapoServer: NSURLProtocol {
 
      Note: calls to `stopLoading()` will set this value to `true`
      */
-    public private(set) var requestCancelled:Bool = false
+    private(set) var requestCancelled:Bool = false
     
     /**
      Register and return a new Router in the Server
@@ -112,10 +107,12 @@ public final class KakapoServer: NSURLProtocol {
     
     /// Start loading the matched requested, the route handler will be called and the returned object will be serialized.
     override public func startLoading() {
-        if requestCancelled == false {
-            if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
-                KakapoServer.routers[routerIndex].startLoading(self)
-            }
+        if requestCancelled {
+            return
+        }
+
+        if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
+            KakapoServer.routers[routerIndex].startLoading(self)
         }
     }
     

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -39,7 +39,12 @@ import Foundation
  ```
  */
 public final class KakapoServer: NSURLProtocol {
-    
+
+    /**
+     The overall list of `Router` objects, which is know to all `KakapoServer` instances.
+     Visibility is on the `KakapoServer` class level, because `NSURLProtocol` just allows us to register
+     class elements (no instances are possible).
+     */
     private static var routers: [Router] = []
     
     /**
@@ -76,7 +81,12 @@ public final class KakapoServer: NSURLProtocol {
     }
     
     /**
-     KakapoServer checks if the given request matches any of the registered routes and determines if the request should be intercepted
+     `KakapoServer` checks if the given request matches any of the registered routes
+     and determines if the request should be intercepted.
+
+     Note: If this method returns `true`, then the OS will create a new `KakapoServer` instance for the `request`
+           via the `init(request:cachedResponse:client:)` initializer. So, this `request` is the same, which
+           we'll have access to later on in the `startLoading()` and `stopLoading()` methods.
      
      - parameter request: A request
      

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -83,7 +83,7 @@ public final class KakapoServer: NSURLProtocol {
      - returns: true if any of the registered route match the request URL
      */
     override public class func canInitWithRequest(request: NSURLRequest) -> Bool {
-        return routers.filter { $0.canInitWithRequest(request) }.first != nil
+        return routers.indexOf({ $0.canInitWithRequest(request) }) != nil
     }
     
     /// Just returns the given request without changes
@@ -92,18 +92,16 @@ public final class KakapoServer: NSURLProtocol {
     }
     
     /// Start loading the matched requested, the route handler will be called and the returned object will be serialized.
-    override public func startLoading() {        
-        guard let router = KakapoServer.routers.filter({ $0.canInitWithRequest(request) }).first else {
-            return
+    override public func startLoading() {
+        if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
+            KakapoServer.routers[routerIndex].startLoading(self)
         }
-        router.startLoading(self)
     }
     
     /// Stops the loading of the matched request.
     override public func stopLoading() {
-        guard let router = KakapoServer.routers.filter({ $0.canInitWithRequest(request) }).first else {
-            return
+        if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
+            KakapoServer.routers[routerIndex].stopLoading(self)
         }
-        router.stopLoading(self)
     }
 }

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 /**
- A server that conforms to NSURLProtocol in order to intercept outgoing network communication.
- You shouldn't use this class directly but register a `Router` instead. Since frameworks like **AFNetworking** and **Alamofire** require manual registration of the `NSURLProtocol` classes you will need to register this class when needed.
+ A server that conforms to `NSURLProtocol` in order to intercept outgoing network communication.
+ You shouldn't use this class directly but register a `Router` instead.
+ Since frameworks like **AFNetworking** and **Alamofire** require manual registration of the `NSURLProtocol` classes
+ you will need to register this class when needed.
 
  ### Examples
  
@@ -45,7 +47,7 @@ public final class KakapoServer: NSURLProtocol {
      
      - parameter baseURL: The base URL that this Router will use
      
-     - returns: An new initializcaRouter objects can hold the same baseURL.
+     - returns: A newly initialized Router object, which is configured to use the `baseURL`.
      */
     class func register(baseURL: String) -> Router {
         NSURLProtocol.registerClass(self)
@@ -90,12 +92,18 @@ public final class KakapoServer: NSURLProtocol {
     }
     
     /// Start loading the matched requested, the route handler will be called and the returned object will be serialized.
-    override public func startLoading() {
-        KakapoServer.routers.filter { $0.canInitWithRequest(request) }.first!.startLoading(self)
+    override public func startLoading() {        
+        guard let router = KakapoServer.routers.filter({ $0.canInitWithRequest(request) }).first else {
+            return
+        }
+        router.startLoading(self)
     }
     
-    /// Not implemented yet, does nothing ATM. https://github.com/devlucky/Kakapo/issues/88
+    /// Stops the loading of the matched request.
     override public func stopLoading() {
-        /* TODO: implement stopLoading for delayed requests https://github.com/devlucky/Kakapo/issues/88 */
+        guard let router = KakapoServer.routers.filter({ $0.canInitWithRequest(request) }).first else {
+            return
+        }
+        router.stopLoading(self)
     }
 }

--- a/Source/KakapoServer.swift
+++ b/Source/KakapoServer.swift
@@ -45,7 +45,16 @@ public final class KakapoServer: NSURLProtocol {
      Visibility is on the `KakapoServer` class level, because `NSURLProtocol` just allows us to register
      class elements (no instances are possible).
      */
-    private static var routers: [Router] = []
+    public static var routers: [Router] = []
+
+    /**
+     `true`, if the `request` of the `KakapoServer` instance has been cancelled, otherwise `false`.
+
+     Default: `false`
+
+     Note: calls to `stopLoading()` will set this value to `true`
+     */
+    public private(set) var requestCancelled:Bool = false
     
     /**
      Register and return a new Router in the Server
@@ -103,15 +112,15 @@ public final class KakapoServer: NSURLProtocol {
     
     /// Start loading the matched requested, the route handler will be called and the returned object will be serialized.
     override public func startLoading() {
-        if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
-            KakapoServer.routers[routerIndex].startLoading(self)
+        if requestCancelled == false {
+            if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
+                KakapoServer.routers[routerIndex].startLoading(self)
+            }
         }
     }
     
     /// Stops the loading of the matched request.
     override public func stopLoading() {
-        if let routerIndex = KakapoServer.routers.indexOf({ $0.canInitWithRequest(request) }) {
-            KakapoServer.routers[routerIndex].stopLoading(self)
-        }
+        requestCancelled = true
     }
 }

--- a/Source/RouteMatcher.swift
+++ b/Source/RouteMatcher.swift
@@ -14,7 +14,7 @@ import Foundation
 public typealias URLInfo = (components: [String : String], queryParameters: [NSURLQueryItem])
 
 /**
- Match a route and a requestURL. A route is composed by a baseURL and a path, togheter they should match the given requestURL.
+ Match a route and a requestURL. A route is composed by a baseURL and a path, together they should match the given requestURL.
  To match a route the baseURL must be contained in the requestURL, the substring of the requestURL following the baseURL then is tested against the path to check if they match.
  A baseURL can contain a scheme, and the requestURL must match the scheme; if it doesn't contain a scheme then the baseURL is a wildcard and will be matched by any subdomain or any scheme:
  
@@ -23,7 +23,7 @@ public typealias URLInfo = (components: [String : String], queryParameters: [NSU
  - base: `kakapo.com`, path: "any", requestURL: "https://kakapo.com/any" ✅
  - base: `kakapo.com`, path: "any", requestURL: "https://api.kakapo.com/any" ✅
  
- A path can contain wildcard components prefixed with ":" (e.g. /users/:userid) that are used to build the component dictionary, the wildcard is then used as key and the repsective component of the requestURL is used as value.
+ A path can contain wildcard components prefixed with ":" (e.g. /users/:userid) that are used to build the component dictionary, the wildcard is then used as key and the respective component of the requestURL is used as value.
  Any component that is not a wildcard have to be exactly the same in both the path and the request, otherwise the route won't match.
  
  - `/users/:userid` and `/users/1234` ✅ -> `[userid: 1234]`
@@ -35,7 +35,7 @@ public typealias URLInfo = (components: [String : String], queryParameters: [NSU
  - parameter path:       The path of the request, can contain wildcards components prefixed with ":" (e.g. /users/:id/)
  - parameter requestURL: The URL of the request (e.g. https://kakapo.com/api/users/1234)
  
- - returns: A URL info object containing `components` and `queryParamaters` or nil if `requestURL`doesn't match the route.
+ - returns: A URL info object containing `components` and `queryParameters` or nil if `requestURL`doesn't match the route.
  */
 func matchRoute(baseURL: String, path: String, requestURL: NSURL) -> URLInfo? {
     
@@ -91,7 +91,7 @@ private extension String {
     }
     
     /**
-     Retrun the substring From/To a given string or nil if the string is not contained.
+     Return the substring From/To a given string or nil if the string is not contained.
      - **From**: return the substring following the given string (e.g. `kakapo.com/users`, `kakapo.com` -> `/users`)
      - **To**: return the substring preceding the given string (e.g. `kakapo.com/users?a=b`, `?` -> `kakapo.com/users`)
      */

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -102,12 +102,12 @@ public final class Router {
     }
     
     private var routes: [String : Route] = [:]
-    private var canceledRequests: [NSURLProtocol] = []
-    
+    private var canceledRequests: [NSURL] = []
+
     /// The `baseURL` of the Router
     public let baseURL: String
     
-    /// The desired latency to delay the mocked responses. Default value is 0.
+    /// The desired latency (in seconds) to delay the mocked responses. Default value is 0.
     public var latency: NSTimeInterval = 0
     
     
@@ -218,9 +218,9 @@ public final class Router {
             guard let strongSelf = self else {
                 return
             }
-            if let serverIndex = strongSelf.canceledRequests.indexOf(server) {
-                // remove server from the list of "canceled requests" and DO NOT send notification(s)
-                strongSelf.canceledRequests.removeAtIndex(serverIndex)
+            if let canceledRequestIndex = strongSelf.canceledRequests.indexOf(requestURL) {
+                // remove request URL from the list of "canceled requests" and DO NOT send notification(s)
+                strongSelf.canceledRequests.removeAtIndex(canceledRequestIndex)
             }
             else {
                 didFinishLoading(server)
@@ -229,8 +229,12 @@ public final class Router {
     }
 
     func stopLoading(server: NSURLProtocol) {
-        if canceledRequests.contains(server) == false {
-            canceledRequests.append(server)
+        guard let requestURL = server.request.URL else {
+            return
+        }
+        // if request URL not in the list of "to be canceled" requests -> enqueue it
+        if canceledRequests.contains(requestURL) == false {
+            canceledRequests.append(requestURL)
         }
     }
     

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -215,14 +215,7 @@ public final class Router {
         dispatch_after(delayTime, dispatch_get_main_queue()) {
             [weak self] in
             // before reporting "finished", check if request has been canceled in the meantime
-            guard let strongSelf = self else {
-                return
-            }
-            if let canceledRequestIndex = strongSelf.canceledRequests.indexOf(requestURL) {
-                // remove request URL from the list of "canceled requests" and DO NOT send notification(s)
-                strongSelf.canceledRequests.removeAtIndex(canceledRequestIndex)
-            }
-            else {
+            if self?.cancelRequest(requestURL) == false {
                 didFinishLoading(server)
             }
         }
@@ -237,7 +230,7 @@ public final class Router {
             canceledRequests.append(requestURL)
         }
     }
-    
+
     /**
      Registers a GET request with the given path.
      
@@ -324,6 +317,23 @@ public final class Router {
      */
     public func put(path: String, handler: RouteHandler) {
         routes[path] = (.PUT, handler)
+    }
+
+    /**
+     Determines, if the `requestURL` has been marked as "should be canceled" or not.
+
+     - return: `true` if the `requestURL` should be canceled, otherwise `false`
+     */
+    private func cancelRequest(requestURL: NSURL) -> Bool {
+        var requestUrlCanceled = false
+
+        if let canceledRequestIndex = canceledRequests.indexOf(requestURL) {
+            // remove request URL from the list of "canceled requests" and DO NOT send notification(s)
+            canceledRequests.removeAtIndex(canceledRequestIndex)
+            requestUrlCanceled = true
+        }
+
+        return requestUrlCanceled
     }
     
 }

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -35,7 +35,8 @@ public struct Request {
 
 /**
  A protocol to adopt when a `Serializable object needs to also provide response status code and/or headerFields
- For example you may use `Response` to wrap your `Serializable` object to just achieve the result or directly implement the protocol. For examply `JSONAPISerializer` implement the protocol in order to be able to provide custom status code in the response.
+ For example you may use `Response` to wrap your `Serializable` object to just achieve the result or directly implement the protocol.
+ For example `JSONAPISerializer` implement the protocol in order to be able to provide custom status code in the response.
  */
 public protocol ResponseFieldsProvider: CustomSerializable {
     /// The response status code
@@ -59,7 +60,7 @@ extension ResponseFieldsProvider {
 /**
  A ResponseFieldsProvider implementation which can be used in `RouteHandlers` to provide valid responses that can return different status code than the default (200) or headerFields.
  
- The struct provides, appart from a Serializable `body` object, a status code and header fields. 
+ The struct provides, apart from a Serializable `body` object, a status code and header fields.
  */
 public struct Response: ResponseFieldsProvider {
     /// The response status code
@@ -72,11 +73,11 @@ public struct Response: ResponseFieldsProvider {
     public let headerFields: [String : String]?
     
     /**
-     Initialize `Response` object that wraps another `Serializable` object for the serialization but, implemententing `ResponseFieldsProvider` can affect some parameters of the HTTP response
+     Initialize `Response` object that wraps another `Serializable` object for the serialization but, implementing `ResponseFieldsProvider` can affect some parameters of the HTTP response
      
-     - parameter statusCode:   the status code that the response should provide to the HTTP repsonse
+     - parameter statusCode:   the status code that the response should provide to the HTTP response
      - parameter body:         the body that will be serialized
-     - parameter headerFields: the headerFields that the response should provide to the HTTP repsonse
+     - parameter headerFields: the headerFields that the response should provide to the HTTP response
      
      - returns: A wrapper `Serializable` object that affect http requests.
      */
@@ -101,6 +102,7 @@ public final class Router {
     }
     
     private var routes: [String : Route] = [:]
+    private var canceledRequests: [NSURLProtocol] = []
     
     /// The `baseURL` of the Router
     public let baseURL: String
@@ -110,8 +112,9 @@ public final class Router {
     
     
     /**
-     Register a new Router in the KakapoServer.
-     The baseURL can contain a scheme, and the requestURL must match the scheme; if it doesn't contain a scheme then the baseURL is a wildcard and will be matched by any subdomain or any scheme:
+     Register a new Router in the `KakapoServer`.
+     The `baseURL` can contain a scheme, and the requestURL must match the scheme; if it doesn't contain a scheme then
+     the `baseURL` is a wildcard and will be matched by any subdomain or any scheme:
      
      - base: `http://kakapo.com`, path: "any", requestURL: "http://kakapo.com/any" ✅
      - base: `http://kakapo.com`, path: "any", requestURL: "https://kakapo.com/any" ❌ because it's **https**
@@ -210,14 +213,31 @@ public final class Router {
 
         let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(latency * Double(NSEC_PER_SEC)))
         dispatch_after(delayTime, dispatch_get_main_queue()) {
-            didFinishLoading(server)
+            [weak self] in
+            // before reporting "finished", check if request has been canceled in the meantime
+            guard let strongSelf = self else {
+                return
+            }
+            if let serverIndex = strongSelf.canceledRequests.indexOf(server) {
+                // remove server from the list of "canceled requests" and DO NOT send notification(s)
+                strongSelf.canceledRequests.removeAtIndex(serverIndex)
+            }
+            else {
+                didFinishLoading(server)
+            }
+        }
+    }
+
+    func stopLoading(server: NSURLProtocol) {
+        if canceledRequests.contains(server) == false {
+            canceledRequests.append(server)
         }
     }
     
     /**
      Registers a GET request with the given path.
      
-     The path is used togheter with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retreive the components of the request:
+     The path is used together with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retrieve the components of the request:
      
      - "/users/:userid" and "/users/1234" will produce [userid: 1234]
      
@@ -239,7 +259,7 @@ public final class Router {
     /**
      Registers a POST request with the given path
      
-     The path is used togheter with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retreive the components of the request:
+     The path is used together with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retrieve the components of the request:
      
      - "/users/:userid" and "/users/1234" will produce [userid: 1234]
      
@@ -261,7 +281,7 @@ public final class Router {
     /**
      Registers a DEL request with the given path
      
-     The path is used togheter with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retreive the components of the request:
+     The path is used together with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retrieve the components of the request:
      
      - "/users/:userid" and "/users/1234" will produce [userid: 1234]
      
@@ -283,7 +303,7 @@ public final class Router {
     /**
      Registers a PUT request with the given path
      
-     The path is used togheter with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retreive the components of the request:
+     The path is used together with the `Router.baseURL` to match requests. It can contain wildcard components prefixed by ":" that are later used to retrieve the components of the request:
      
      - "/users/:userid" and "/users/1234" will produce [userid: 1234]
      

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -109,8 +109,14 @@ public final class Router {
     
     /// The desired latency (in seconds) to delay the mocked responses. Default value is 0.
     public var latency: NSTimeInterval = 0
-    
-    
+
+    /// The number of requests, which are currently marked for 'cancellation' on the receiver
+    public var numberOfCancelledRequests: Int {
+        get {
+            return canceledRequests.count
+        }
+    }
+
     /**
      Register a new Router in the `KakapoServer`.
      The `baseURL` can contain a scheme, and the requestURL must match the scheme; if it doesn't contain a scheme then
@@ -221,6 +227,9 @@ public final class Router {
         }
     }
 
+    /**
+     Tells the receiver to stop loading the `request` of the `server`
+     */
     func stopLoading(server: NSURLProtocol) {
         guard let requestURL = server.request.URL else {
             return

--- a/Source/SerializationTransformer.swift
+++ b/Source/SerializationTransformer.swift
@@ -73,7 +73,7 @@ public struct SnakecaseTransformer<Wrapped: Serializable>: SerializationTransfor
      
      - parameter wrapped: A wrapped `Serializable` object
      
-     - returns: A `Serializable` object that will trasform the keys of the wrapped object when serialzied.
+     - returns: A `Serializable` object that will transform the keys of the wrapped object when serialized.
      */
     public init(_ wrapped: Wrapped) {
         self.wrapped = wrapped
@@ -102,10 +102,10 @@ private extension String {
         
         for (idx, c) in charactersView.reverse().enumerate() {
             let char = String(c)
-            let lowercased = char.lowercaseString
-            let isUppercase = char != lowercased
+            let lowerCased = char.lowercaseString
+            let isUppercase = char != lowerCased
             
-            string.insert(Character(lowercased), atIndex: startIndex)
+            string.insert(Character(lowerCased), atIndex: startIndex)
             
             if isUppercase && idx != endIndex {
                 string.insert("_", atIndex: startIndex)

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -45,7 +45,7 @@ public extension Serializable {
     }
 
     /**
-     Serialize a `Serializable` object and convert the serialzied object to `Data`. Unless it is nil the return value is representing a JSON. Usually you don't need to use this method directly since `Router` will automatically serialize objects when needed.
+     Serialize a `Serializable` object and convert the serialized object to `Data`. Unless it is nil the return value is representing a JSON. Usually you don't need to use this method directly since `Router` will automatically serialize objects when needed.
      
      - returns: The serialized object as `Data`
      */
@@ -126,7 +126,7 @@ private func serializeObject(value: Any, keyTransformer: KeyTransformer?) -> Any
  - parameter object: A Serializable object, not a `CustomSerializable`
  - parameter keyTransformer: The keyTransformer to be used, if not nil, to transform the keys of the json
  
- - returns: A serialized object that may be convered to JSON, usually Array or Dictionary
+ - returns: A serialized object that may be converted to JSON, usually Array or Dictionary
  */
 private func serialize(object: Serializable, keyTransformer: KeyTransformer?) -> AnyObject {
     assert(!(object is CustomSerializable))

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -120,8 +120,8 @@ class RouterTests: QuickSpec {
             }
 
             it("should not confuse multiple request with identical URL") {
-                var responseError_A: NSError? = nil
-                var responseError_B: NSError? = nil
+                var responseError_A: NSError?
+                var responseError_B: NSError?
                 let canceledRequestID = "999"
 
                 router.get("/cash/:id") { request in

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -119,19 +119,6 @@ class RouterTests: QuickSpec {
                 let urlProtocol = NSURLProtocol(request: urlRequest, cachedResponse: nil, client: nil)
                 router.stopLoading(urlProtocol)
             }
-
-            it("should remember a request in the 'cancel request list', when request is stopped") {
-
-                let requestURL = NSURL(string: "http://www.test.com/users/1")!
-
-                // We create a "dummy" NSURLProtocol object here, which is using the same URL (that we used to
-                // trigger the request). In order to check the request cancelation.
-                let urlRequest = NSURLRequest(URL: requestURL)
-                let urlProtocol = NSURLProtocol(request: urlRequest, cachedResponse: nil, client: nil)
-                router.stopLoading(urlProtocol)
-
-                expect(router.canceledRequests.count) == 1
-            }
         }
 
         describe("Registering urls") {

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -119,7 +119,7 @@ class RouterTests: QuickSpec {
                 expect(responseError?.localizedDescription).toEventually(equal("cancelled"), timeout: (latency + 1))
             }
 
-            it("should not confused multiple request with identical URL") {
+            it("should not confuse multiple request with identical URL") {
                 var responseError_A: NSError? = nil
                 var responseError_B: NSError? = nil
                 let canceledRequestID = "999"

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -142,7 +142,6 @@ class RouterTests: QuickSpec {
                     responseURL = response?.URL
                 }
 
-                dataTask.resume()
                 dataTask.cancel() // immediately stop the request loading
 
                 expect(responseURL).toEventually(beNil())


### PR DESCRIPTION
### General description

Implemented the `NSURLProtocol#stopLoading()` logic in `KakapoServer`

After the `latency` feature has been added to `Router`, which allows to delay the request callback reporting, it is now possible that a request may be waiting for its callback, but `KakapoServer` gets commanded to cancel the particular request.

This pull requests makes the full roundtrip and adds the capability to "not complete" the request, if `KakapoServer` command so.
### Primarily affected components
- `KakapoServer` & `Router`
### Depending components
- none
### Expected possible Pitfalls
- none
### Device and OS test coverage
- Test on iPhone 5, iOS 8: untested
- Test on iPhone 6S, iOS 9: `leviathan`
- Test on iPad, iOS 8: untested
- Test on iPad, iOS 9: untested
- Test on Watch, watchOS 2: untested

Closes #88 
