### PR TITLE
FIX-ATTEMPT: Try to use a class instead of mutating struct for JSONAPIError.Builder

### DIFF
--- a/Source/JSONAPIError.swift
+++ b/Source/JSONAPIError.swift
@@ -34,7 +34,7 @@ public struct JSONAPIError: ResponseFieldsProvider {
     }
     
     /// A builder for JSONAPIError
-    public struct Builder: Serializable {
+    public class Builder: Serializable {
         
         /// A unique identifier for this particular occurrence of the problem.
         public var id: String?
@@ -96,9 +96,9 @@ public struct JSONAPIError: ResponseFieldsProvider {
      
      - returns: An error that conforms to JSON API specifications and it's ready to be serialized
      */
-    public init(statusCode: Int, headerFields: [String: String]? = nil, errorBuilder: (error: inout Builder) -> ()) {
-        var builder = Builder(statusCode: statusCode)
-        errorBuilder(error: &builder)
+    public init(statusCode: Int, headerFields: [String: String]? = nil, errorBuilder: (error: Builder) -> ()) {
+        let builder = Builder(statusCode: statusCode)
+        errorBuilder(error: builder)
         self.builder = builder
         self.headerFields = headerFields
     }


### PR DESCRIPTION
Hopefully fixes #79 

theory some bug while mutating the struct prevent it to work correctly? I don't think it's a Router issue because only happens with this test
