### PR TITLE
Feature/query parameter router matching

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ### HEAD
 --------------
 
+- Added support for query parameter routing [Landsi](https://github.com/landsi)
+
 ### 2.1.0
 -----------
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,16 @@ session.dataTask(with: url) { (data, _, _) in
 }.resume()
 ```
 
-> Note: query parameters are not affecting the route match
-> `http://www.test.com/users/1?foo=bar` would also be matched
+> Note: If query parameters are provided in the route, they are also affecting the route match and can contain wildcard components!
+
+For instance:
+```Swift
+let router = Router.register("http://www.test.com")
+
+// Will match http://www.test.com/users?country=spain
+router.get("/users?country=:country") { request in ... } // request.components["country"] will contain "spain"
+```
+
 
 In the previous example the handler was returning a simple `Dictionary`; while this works because `Dictionary` is already `Serializable`, you can also create your own entities that conform to `Serializable`:
 

--- a/README.md
+++ b/README.md
@@ -163,14 +163,13 @@ session.dataTask(with: url) { (data, _, _) in
 }.resume()
 ```
 
-> Note: If query parameters are provided in the route, they are also affecting the route match and can contain wildcard components!
+If query parameters are provided in the route, they are also affecting the route match and can contain wildcard components too:
 
-For instance:
 ```Swift
 let router = Router.register("http://www.test.com")
 
 // Will match http://www.test.com/users?country=spain
-router.get("/users?country=:country") { request in ... } // request.components["country"] will contain "spain"
+router.get("/users?country=:country") { request in ... } // request.components["country"] => "spain"
 ```
 
 

--- a/Source/RouteMatcher.swift
+++ b/Source/RouteMatcher.swift
@@ -45,7 +45,7 @@ public typealias URLInfo = (components: [String : String], queryParameters: [URL
  
  - returns: A URL info object containing `components` and `queryParameters` or nil if `requestURL`doesn't match the route.
  */
-func matchRoute(_ baseURL: String, path: String, queryParameters: [URLQueryItem] = [], requestURL: URL) -> URLInfo? {
+func matchRoute(_ baseURL: String, path: String, queryParameters: Set<URLQueryItem> = [], requestURL: URL) -> URLInfo? {
     
     // remove the baseURL and the params, if baseURL is not in the string the result will be nil
     guard let relevantURL: String = {
@@ -118,7 +118,7 @@ fileprivate func routeComponentsMatch(routePathComponents: [String], requestPath
     return components
 }
 
-fileprivate func queryComponentsMatch(queryParameters: [URLQueryItem], requestQueryParameters: [URLQueryItem]?) -> [String : String]? {
+fileprivate func queryComponentsMatch(queryParameters: Set<URLQueryItem>, requestQueryParameters: [URLQueryItem]?) -> [String : String]? {
     var components: [String : String] = [:]
     
     // also check for query items for route matching and component extraction

--- a/Source/RouteMatcher.swift
+++ b/Source/RouteMatcher.swift
@@ -139,11 +139,6 @@ fileprivate func queryComponentsMatch(queryParameters: Set<URLQueryItem>, reques
                     return nil // if no componentKey can be found, we cannot match as it's not equal nor a wildcard
                 }
                 
-                // if the key is equal to the requestComponent then its not a wildcard, no need to insert it in components
-                if componentKey == requestValue {
-                    continue
-                }
-                
                 components[componentKey] = requestValue
             }
         }

--- a/Source/RouteMatcher.swift
+++ b/Source/RouteMatcher.swift
@@ -14,8 +14,9 @@ import Foundation
 public typealias URLInfo = (components: [String : String], queryParameters: [URLQueryItem])
 
 /**
- Match a route and a requestURL. A route is composed by a baseURL and a path, together they should match the given requestURL.
+ Match a route and a requestURL. A route is composed by a baseURL, a path and optional query items. Together they should match the given requestURL.
  To match a route the baseURL must be contained in the requestURL, the substring of the requestURL following the baseURL then is tested against the path to check if they match.
+ Also, all query items, if provided, must be contained in the requestURL for it to match
  A baseURL can contain a scheme, and the requestURL must match the scheme; if it doesn't contain a scheme then the baseURL is a wildcard and will be matched by any subdomain or any scheme:
  
  - base: `http://kakapo.com`, path: "any", requestURL: "http://kakapo.com/any" ✅
@@ -29,11 +30,18 @@ public typealias URLInfo = (components: [String : String], queryParameters: [URL
  - `/users/:userid` and `/users/1234` ✅ -> `[userid: 1234]`
  - `/comment/:commentid` and `/users/1234` ❌
 
- QueryParameters are stripped from requestURL before the matching and used to fill `URLInfo.queryParamters`, anything after "?" won't affect the matching.
+ Query Items can also contain wildcard components prefixed with ":" (e.g. "?language=:lng") that are included in the component dictionary, the wildcard is then used as key and the respective component of the requestURL is used as value.
+ Any component that is not a wildcard have to be exactly the same in both the path and the request, otherwise the route won't match.
  
- - parameter baseURL:    The base url, can contain the scheme or not but must be contained in the `requestURL`, (e.g. http://kakapo.com/api) if the baseURL doesn't contain the scheme it's considered as a wildcard that match any scheme and subdomain, see the examples above.
- - parameter path:       The path of the request, can contain wildcards components prefixed with ":" (e.g. /users/:id/)
- - parameter requestURL: The URL of the request (e.g. https://kakapo.com/api/users/1234)
+ - `?language=:lng` and `?language=en` ✅ -> `[lng: en]`
+ - `?language=:lng` and `?location=hotel` ❌
+
+ Query Items are also filled in `URLInfo.queryParamters` to be used as needed.
+ 
+ - parameter baseURL:           The base url, can contain the scheme or not but must be contained in the `requestURL`, (e.g. http://kakapo.com/api) if the baseURL doesn't contain the scheme it's considered as a wildcard that match any scheme and subdomain, see the examples above.
+ - parameter path:              The path of the route, can contain wildcards components prefixed with ":" (e.g. /users/:id/)
+ - parameter queryParameters:   The query parameters of the route, can contain wildcards components prefixed with ":" (e.g. ?language=:lng)
+ - parameter requestURL:        The URL of the request (e.g. https://kakapo.com/api/users/1234)
  
  - returns: A URL info object containing `components` and `queryParameters` or nil if `requestURL`doesn't match the route.
  */
@@ -54,39 +62,70 @@ func matchRoute(_ baseURL: String, path: String, queryParameters: [URLQueryItem]
         return nil
     }
     
-    if queryParameters.count > 0 {
-        guard let requestQueryItems = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?.queryItems, Set(queryParameters).isSubset(of: Set(requestQueryItems)) else {
-            // if query parameters are provided for route matching, all query parameters must be included in the request for it to match
-            return nil
-        }
-    }
-    
     var components: [String : String] = [:]
-
+    let requestQueryParameters = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?.queryItems
+    
     for (routeComponent, requestComponent) in zip(routePathComponents, requestPathComponents) {
         // [users, users], [:userid, 1234]
         
-        // if they are not equal then it must be a key prefixed by ":" otherwise the route is not matched
-        if routeComponent == requestComponent {
-            continue // not a wildcard, no need to insert it in components
-        } else {
-            guard let firstChar = routeComponent.characters.first, firstChar == ":" else {
-                return nil // not equal nor a wildcard
-            }
+        guard let componentKey = componentKey(routeComponent: routeComponent, requestComponent: requestComponent) else {
+            return nil // if no componentKey can be found, we cannot match as it's not equal nor a wildcard
+        }
+
+        // if the key is equal to the requestComponent then its not a wildcard, no need to insert it in components
+        if componentKey == requestComponent {
+            continue
         }
         
-        let relevantKeyIndex = routeComponent.characters.index(after: routeComponent.characters.startIndex) // second position
-        let key = routeComponent.substring(from: relevantKeyIndex) // :key -> key
-        components[key] = requestComponent
+        components[componentKey] = requestComponent
+    }
+    
+    // also check for query items for route matching and component extraction
+    if queryParameters.count > 0 {
+        guard let requestQueryParameters = requestQueryParameters, Set(queryParameters.map{ $0.name }).isSubset(of: Set(requestQueryParameters.map{ $0.name })) else {
+            // if query parameters are provided for route matching, all query parameters must be included in the request for it to match
+            return nil
+        }
+        
+        for routeQueryItem in queryParameters {
+            if let requestQueryItem = requestQueryParameters.first(where: { $0.name == routeQueryItem.name }),
+                let routeValue = routeQueryItem.value,
+                let requestValue = requestQueryItem.value,
+                routeValue != requestValue {
+                // "method=search", "language=:lng"
+                
+                guard let componentKey = componentKey(routeComponent: routeValue, requestComponent: requestValue) else {
+                    return nil // if no componentKey can be found, we cannot match as it's not equal nor a wildcard
+                }
+                
+                // if the key is equal to the requestComponent then its not a wildcard, no need to insert it in components
+                if componentKey == requestValue {
+                    continue
+                }
+                
+                components[componentKey] = requestValue
+            }
+        }
     }
 
-    // get the parameters [a:b]
-    let queryItems = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?.queryItems
-
-    return (components, queryItems ?? [])
+    return (components, requestQueryParameters ?? [])
 }
 
-private extension String {
+fileprivate func componentKey(routeComponent: String, requestComponent: String) -> String? {
+    // if they are not equal then it must be a key prefixed by ":" otherwise the route is not matched
+    if routeComponent == requestComponent {
+        return routeComponent // not a wildcard, return the original string
+    } else {
+        guard let firstChar = routeComponent.characters.first, firstChar == ":" else {
+            return nil // not equal nor a wildcard
+        }
+    }
+    
+    let relevantKeyIndex = routeComponent.characters.index(after: routeComponent.characters.startIndex) // second position
+    return routeComponent.substring(from: relevantKeyIndex) // :key -> key
+}
+
+internal extension String {
     
     func split(_ separator: Character) -> [String] {
         return characters.split(separator: separator).map { String($0) }

--- a/Source/RouteMatcher.swift
+++ b/Source/RouteMatcher.swift
@@ -37,7 +37,7 @@ public typealias URLInfo = (components: [String : String], queryParameters: [URL
  
  - returns: A URL info object containing `components` and `queryParameters` or nil if `requestURL`doesn't match the route.
  */
-func matchRoute(_ baseURL: String, path: String, requestURL: URL) -> URLInfo? {
+func matchRoute(_ baseURL: String, path: String, queryParameters: [URLQueryItem] = [], requestURL: URL) -> URLInfo? {
     
     // remove the baseURL and the params, if baseURL is not in the string the result will be nil
     guard let relevantURL: String = {
@@ -52,6 +52,13 @@ func matchRoute(_ baseURL: String, path: String, requestURL: URL) -> URLInfo? {
     guard routePathComponents.count == requestPathComponents.count else {
         // different components count means that the path can't match
         return nil
+    }
+    
+    if queryParameters.count > 0 {
+        guard let requestQueryItems = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?.queryItems, Set(queryParameters).isSubset(of: Set(requestQueryItems)) else {
+            // if query parameters are provided for route matching, all query parameters must be included in the request for it to match
+            return nil
+        }
     }
     
     var components: [String : String] = [:]

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -98,20 +98,20 @@ public final class Router {
     private class Route: Hashable {
         let path: String
         let method: HTTPMethod
-        let queryParameters: [URLQueryItem]
+        let queryParameters: Set<URLQueryItem>
         
         static func == (lhs: Router.Route, rhs: Router.Route) -> Bool {
             return lhs.path == rhs.path && lhs.method == rhs.method && lhs.queryParameters == rhs.queryParameters
         }
         
-        init(path: String, method: HTTPMethod, queryParameters: [URLQueryItem] = []) {
+        init(path: String, method: HTTPMethod, queryParameters: Set<URLQueryItem> = []) {
             self.path = path
             self.method = method
             self.queryParameters = queryParameters
         }
         
         var hashValue: Int {
-            return queryParameters.reduce(path.hashValue ^ method.hashValue) { $0.0 ^ $0.1.hashValue} << 8
+            return queryParameters.reduce(path.hashValue ^ method.hashValue) { $0.0 ^ $0.1.hashValue }
         }
     }
     
@@ -246,7 +246,7 @@ public final class Router {
             queryParameters = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
         }
         
-        routes[Route(path: route, method: method, queryParameters: queryParameters ?? [])] = handler
+        routes[Route(path: route, method: method, queryParameters: Set(queryParameters ?? []))] = handler
     }
 
     /**

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -98,18 +98,20 @@ public final class Router {
     private class Route: Hashable {
         let path: String
         let method: HTTPMethod
+        let queryParameters: [URLQueryItem]
         
         static func == (lhs: Router.Route, rhs: Router.Route) -> Bool {
-            return lhs.path == rhs.path && lhs.method == rhs.method
+            return lhs.path == rhs.path && lhs.method == rhs.method && lhs.queryParameters == rhs.queryParameters
         }
         
-        init(path: String, method: HTTPMethod) {
+        init(path: String, method: HTTPMethod, queryParameters: [URLQueryItem] = []) {
             self.path = path
             self.method = method
+            self.queryParameters = queryParameters
         }
         
         var hashValue: Int {
-            return path.hashValue ^ method.hashValue
+            return queryParameters.reduce(path.hashValue ^ method.hashValue) { $0.0 ^ $0.1.hashValue} << 8
         }
     }
     
@@ -183,7 +185,7 @@ public final class Router {
         guard let requestURL = request.url, requestURL.absoluteString.contains(baseURL) else { return false }
         
         for (key, _) in routes where key.method.rawValue == request.httpMethod {
-            if  matchRoute(baseURL, path: key.path, requestURL: requestURL) != nil {
+            if  matchRoute(baseURL, path: key.path, queryParameters: key.queryParameters, requestURL: requestURL) != nil {
                 return true
             }
         }
@@ -200,7 +202,7 @@ public final class Router {
         var serializableObject: Serializable?
         
         for (key, handler) in routes where key.method.rawValue == server.request.httpMethod {
-            if let info = matchRoute(baseURL, path: key.path, requestURL: requestURL) {
+            if let info = matchRoute(baseURL, path: key.path, queryParameters: key.queryParameters, requestURL: requestURL) {
                 // If the request body is nil use `URLProtocol` property see swizzling in `NSMutableURLRequest+FixCopy.m`
                 // using a literal string because a bridging header in the podspec will be more problematic.
                 let dataBody = server.request.httpBody ?? URLProtocol.property(forKey: "kkp_requestHTTPBody", in: server.request) as? Data

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -240,7 +240,13 @@ public final class Router {
     }
     
     private func addRoute(with path: String, method: HTTPMethod, handler: @escaping RouteHandler) {
-        routes[Route(path: path, method: method)] = handler
+        let route = path.substring(.to, string: "?") ?? path
+        var queryParameters: [URLQueryItem]? = nil
+        if let url = URL(string: baseURL.appending(path)) {
+            queryParameters = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+        }
+        
+        routes[Route(path: route, method: method, queryParameters: queryParameters ?? [])] = handler
     }
 
     /**

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -197,6 +197,24 @@ class RouterTests: QuickSpec {
                 expect(responseURL?.absoluteString).toEventually(equal("http://www.test.com?onlyifqueryparam=true"))
             }
             
+            it("should call the handler without the components of query params if not a wildcard ") {
+                var info: URLInfo? = nil
+                var responseURL: URL? = nil
+                
+                router.get("?component=false") { request in
+                    info = (components: request.components, queryParameters: request.queryParameters)
+                    return nil
+                }
+                
+                URLSession.shared.dataTask(with: URL(string: "http://www.test.com?component=false")!) { (data, response, _) in
+                    responseURL = response?.url
+                    }.resume()
+                
+                expect(info?.components).toEventually(beNil())
+                expect(info?.queryParameters).toEventually(equal([URLQueryItem(name: "component", value: "false")]))
+                expect(responseURL?.absoluteString).toEventually(equal("http://www.test.com?component=false"))
+            }
+            
             it("should call the handler when requesting multiple registered urls") {
                 var usersInfo: URLInfo? = nil
                 var usersResponseURL: URL? = nil
@@ -522,6 +540,12 @@ class RouterTests: QuickSpec {
                 
                 router.get("/users?language=:lng&region=:reg") { request in
                     XCTFail("Shouldn't reach here")
+                    info = (components: request.components, queryParameters: request.queryParameters)
+                    return nil
+                }
+                
+                router.get("/users?language=en") { request in
+                    XCTFail("Shouldn't reach here, wrong param value")
                     info = (components: request.components, queryParameters: request.queryParameters)
                     return nil
                 }

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -179,7 +179,7 @@ class RouterTests: QuickSpec {
                 expect(responseURL?.absoluteString).toEventually(equal("http://www.test.com/users/1?onlyifqueryparam=true"))
             }
             
-            it("should call the handler when requesting a url ONLY with query parameters") {
+            it("should call the handler when requesting a url only with query parameters") {
                 var info: URLInfo? = nil
                 var responseURL: URL? = nil
                 
@@ -366,11 +366,9 @@ class RouterTests: QuickSpec {
                 expect(calledLocation2).toEventually(beTrue())
             }
 
-            it("should replace handlers with same path, http methods and query params") {
+            it("should replace handlers with same path and http methods") {
                 var calledFirstPost = false
                 var calledSecondPost = false
-                var calledFirstPatch = false
-                var calledSecondPatch = false
                 
                 router.post("/users/:user_id") { (request) -> Serializable? in
                     calledFirstPost = true
@@ -391,14 +389,18 @@ class RouterTests: QuickSpec {
                 URLSession.shared.dataTask(with: request) { (_, _, _) in }.resume()
                 
                 expect(calledSecondPost).toEventually(beTrue())
-                
+            }
+            
+            it("should replace handlers with same query params") {
+                var calledFirstPatch = false
+                var calledSecondPatch = false
                 
                 router.patch("/users/:user_id?called=:called&author=max") { (request) -> Serializable? in
                     calledFirstPatch = true
                     return nil
                 }
                 
-                request = URLRequest(url: URL(string: "http://www.test.com/users/1?called=true&author=max")!)
+                var request = URLRequest(url: URL(string: "http://www.test.com/users/1?called=true&author=max")!)
                 request.httpMethod = "PATCH"
                 URLSession.shared.dataTask(with: request) { (_, _, _) in }.resume()
                 


### PR DESCRIPTION
I recently stumbled upon a Service API, where the routing was done exclusively with the query parameters.

While that is not that pretty in my opinion, I still needed to mock it for my unit tests.

This PR includes Router matching of query parameters including wildcard values.

Basically, this route registration is now possible:

```Swift
router.get("/users?language=:lng") { request in
    let language = request.components["lng"]
    ...
}

// send request to '.../users?language=xx'
```
