### PR TITLE
Fix handler shouldn’t be called when requests are cancelled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ### HEAD
 --------------
 
+- Fix handler was called even when the request was cancelled
+
 ### 2.1.0
 -----------
 

--- a/Source/Router.swift
+++ b/Source/Router.swift
@@ -228,12 +228,8 @@ public final class Router {
             client.urlProtocolDidFinishLoading(server)
         }
 
-        let deadline = DispatchTime.now() + latency
-        DispatchQueue.main.asyncAfter(deadline: deadline) {
-            // before reporting "finished", check if request has been canceled in the meantime
-            if server.requestCancelled == false {
-                didFinishLoading(server)
-            }
+        if !server.requestCancelled {
+            didFinishLoading(server)
         }
     }
     

--- a/Source/Server.swift
+++ b/Source/Server.swift
@@ -101,12 +101,15 @@ public final class Server: URLProtocol {
     
     /// Start loading the matched requested, the route handler will be called and the returned object will be serialized.
     override public func startLoading() {
-        if requestCancelled {
-            return
-        }
-
         if let routerIndex = Server.routers.index(where: { $0.canInit(with: request) }) {
-            Server.routers[routerIndex].startLoading(self)
+            let router = Server.routers[routerIndex]
+            let deadline = DispatchTime.now() + router.latency
+            
+            DispatchQueue.main.asyncAfter(deadline: deadline) {
+                if !self.requestCancelled {
+                    router.startLoading(self)
+                }
+            }
         }
     }
     

--- a/Tests/JSONAPILinksTests.swift
+++ b/Tests/JSONAPILinksTests.swift
@@ -155,7 +155,6 @@ class JSONAPILinksSpec: QuickSpec {
                     return false
                 }.first!
                 
-                
                 let links = cat2["links"].dictionaryValue
                 expect(links).toNot(beNil())
                 expect(links["test"]).to(equal("hello"))


### PR DESCRIPTION
I noticed the tests were slow and identified one cause, I reduced the latency to test cancelation and now running all tests takes 2 second less
In the meanwhile (while trying to make sure the test was not a false positive) I noticed that the tests were wrong, they never called `resume()` before `cancel()` so we didn’t notice that the handler was actually always called even if the request was cancelled.
I moved the dispatch_after(latency) in the Server so the request doesn’t even start before the latency.