### PR TITLE
Allow `Data` as Serialized object even if is not valid json

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 --------------
 
 - Fix handler was called even when the request was cancelled
+- Allow `Data` as Serialized object even if is not valid json #150
 
 ### 2.1.0
 -----------

--- a/Tests/SerializerTests.swift
+++ b/Tests/SerializerTests.swift
@@ -68,6 +68,13 @@ class SerializeSpec: QuickSpec {
                     expect(serialized["customName"] as? String).to(equal("Alex"))
                 }
             }
+
+            context("when the serialized object is Data") {
+                it("is accepted even if is not valid json") {
+                    let serializable: Serializable = Optional.some(Data())
+                    expect(serializable.toData()).toNot(beNil())
+                }
+            }
         }
         
         describe("Array serialization") {


### PR DESCRIPTION
This enable Kakapo to stub other kind of requests, for example we can create a XMLSerialzier that when serialized returns the object as Data, or we can implementer `Serialziable` for `UIImage`, a really powerful feature that let us use Kakapo not only for JSON responses but every kind of response.
This is a basic change that enable us to do so, some more documentation might be written in future and we might decide to move in a direction where Kakapo is less JSON centric


Example: 

```swift
extension UIImage: ResponseFieldsProvider {

    public var statusCode: Int {
        return 200
    }

    public var body: Serializable {
        return UIImagePNGRepresentation(self)
    }

    public var headerFields: [String : String]? {
        return ["Content-Type": "image/png"]
    }
}
```

Usage:
```swift
router.get("image.png") {
   return UIImage(named: "whatever")
}
```