### PR TITLE
Refactor Kakapo to not be json centric WIP

### DIFF
--- a/Source/Serialization/JSONAPIError.swift
+++ b/Source/Serialization/JSONAPIError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A convenience error object that conform to JSON API
-public struct JSONAPIError: ResponseFieldsProvider {
+public struct JSONAPIError: CustomSerializable {
     
     /// An object containing references to the source of the error, optionally including any of the following members
     public struct Source: Serializable {
@@ -78,29 +78,22 @@ public struct JSONAPIError: ResponseFieldsProvider {
     public var statusCode: Int {
         return builder.status
     }
-    
-    /// A `JSONAPIError.Builder` instance contains all the fields.
-    public var body: Serializable {
-        return builder
-    }
-    
-    /// The headerFields that will be returned by the HTTP response.
-    public let headerFields: [String : String]?
 
     /**
      Initialize a `JSONAPIError` and build it with `JSONAPIError.Builder`
      
      - parameter statusCode:   The status code of the response, will be used also to provide a statusCode for your request
-     - parameter headerFields: The headerFields that will be returned by the HTTP response.
      - parameter errorBuilder: A builder that can be used to fill the error objects, it contains all you need to provide an error object confiorming to JSON API (**see `JSONAPIError.Builder`**)
      
      - returns: An error that conforms to JSON API specifications and it's ready to be serialized
      */
-    public init(statusCode: Int, headerFields: [String: String]? = nil, errorBuilder: (_ error: Builder) -> Void) {
+    public init(statusCode: Int, errorBuilder: (_ error: Builder) -> Void) {
         let builder = Builder(statusCode: statusCode)
         errorBuilder(builder)
         self.builder = builder
-        self.headerFields = headerFields
     }
-    
+
+    public func customSerialized(transformingKeys keyTransformer: KeyTransformer?) -> Any? {
+        return builder.serialized()
+    }
 }

--- a/Source/Serialization/ResponseFieldsProvider.swift
+++ b/Source/Serialization/ResponseFieldsProvider.swift
@@ -13,21 +13,13 @@ import Foundation
  For example you may use `Response` to wrap your `Serializable` object to just achieve the result or directly implement the protocol.
  For example `JSONAPIError` implement the protocol in order to be able to provide custom status code in the response.
  */
-public protocol ResponseFieldsProvider: CustomSerializable {
+public protocol ResponseFieldsProvider {
     /// The response status code
     var statusCode: Int { get }
 
     /// The Serializable body object
-    var body: Serializable { get }
+    var body: Data? { get }
 
     /// An optional dictionary holding the response header fields
     var headerFields: [String : String]? { get }
-}
-
-extension ResponseFieldsProvider {
-
-    /// The default implementation just return the serialized body.
-    public func customSerialized(transformingKeys keyTransformer: KeyTransformer?) -> Any? {
-        return body.serialized(transformingKeys: keyTransformer)
-    }
 }

--- a/Tests/JSONAPIErrorTests.swift
+++ b/Tests/JSONAPIErrorTests.swift
@@ -80,30 +80,8 @@ class JSONAPIErrorsSpec: QuickSpec {
                         let response = response as! HTTPURLResponse
                         statusCode = response.statusCode
                         }.resume()
-                    // still the only test randomly failing for no reasons...
-                    // 99,9 % is not a router problem (otherwise wouldn't be the only one)
-                    // https://pbs.twimg.com/media/CfSQdwUW8AErog1.jpg
+
                     expect(statusCode).toEventually(equal(403), timeout: 2)
-                }
-                
-                it("should affect the header fields of the response") {
-                    let router = Router.register("http://www.test1234.com")
-                    
-                    router.get("/users") { _ in
-                        return JSONAPIError(statusCode: 404, headerFields: ["foo": "bar"]) { (error) in
-                            error.title = "test"
-                        }
-                    }
-                    
-                    var foo: String?
-                    let url = URL(string: "http://www.test1234.com/users")!
-                    URLSession.shared.dataTask(with: url) { (_, response, _) in
-                        let response = response as! HTTPURLResponse
-                        let headers = response.allHeaderFields as? [String: String]
-                        foo = headers?["foo"]
-                        }.resume()
-                    
-                    expect(foo).toEventually(equal("bar"))
                 }
             }
         }

--- a/Tests/SerializationTransformerTests.swift
+++ b/Tests/SerializationTransformerTests.swift
@@ -145,14 +145,6 @@ class SerializationTransformerSpec: QuickSpec {
                 }
             }
             
-            context("ResponseFieldsProvider") {
-                it("should transform the keys") {
-                    let object = Response(statusCode: 200, body: friend)
-                    let serialized = UppercaseTransformer(wrapped: object).serialized() as! [String: AnyObject]
-                    expect(serialized["FRIENDS"]).toNot(beNil())
-                }
-            }
-            
             context("Array") {
                 it("should transform the keys") {
                     let object = [friend]

--- a/Tests/SerializerTests.swift
+++ b/Tests/SerializerTests.swift
@@ -156,7 +156,7 @@ class SerializeSpec: QuickSpec {
             it("produces nil data and serialized object when nil") {
                 let nilInt: Int? = nil
                 expect(nilInt.serialized()).to(beNil())
-                expect(nilInt.toData()).to(beNil())
+                expect(nilInt.body).to(beNil())
             }
             
             it("serialize an optional") {


### PR DESCRIPTION
This is a draft PR to address #153, I want some feedback before proceeding with updating the documentation, README, tests
The idea is that Router now doesn’t work anymore w/ `Serializable` objects and `ResponseFieldsProvider` is not anymore a special `Serializable`.
Router now only accept `ResponseFieldsProvider`s an object that provides:
statusCode (Int)
headerfields (dict)
body (data)

`Serializable` became a `ResponseFieldsProvider` that by default has a status code == 200 and “Content-Type” == “application/json”.
It should have been like that since ever, so we can use Kakapo with images, xml or whatever we want by creating new `ResponseFieldsProvider `

The change is a breaking change but not a big one for users of Kakapo (only objects that were confirming to ResponseFieldsProvider will be broken)