### PR TITLE
Fix SwiftLint errors

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -49,5 +49,9 @@ variable_name:
     - HTTPHeaders
     - lhs
     - rhs    
+    - to
+    - obj
+    - get
+    - put
 
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -437,7 +437,7 @@ class RouterTests: QuickSpec {
                     return nil
                 }
                 
-                let _ = NSURLConnection(request: request, delegate: nil)
+                _ = NSURLConnection(request: request, delegate: nil)
                 
                 expect(info?.components).toEventually(equal(["id": "1"]))
                 expect(info?.queryParameters).toEventually(equal([]))
@@ -830,7 +830,7 @@ class RouterTests: QuickSpec {
                 
                 var info: URLInfo? = nil
                 var responseURL: URL? = nil
-                let _ = Router.register("http://www.host2.com")
+                _ = Router.register("http://www.host2.com")
                 
                 router.get("/users/:id") { request in
                     XCTFail("Shouldn't reach here")

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -374,7 +374,7 @@ class StoreTests: QuickSpec {
             
             it("should not deadlock when synchronously writing from another queue into the store during a writing operation") {
                 let user = sut.insert { (id) -> User in
-                    let _ = queue.sync {
+                    _ = queue.sync {
                         sut.insert { (id) -> User in
                             return User(id: id, store: sut)
                         }
@@ -395,7 +395,7 @@ class StoreTests: QuickSpec {
             
             it("should not deadlock when synchronously writing from another queue into the store during a reading operation") {
                 let result = sut.filter(User.self, isIncluded: { (_) -> Bool in
-                    let _ = queue.sync {
+                    _ = queue.sync {
                         sut.create(User.self)
                     }
                     return true
@@ -406,7 +406,7 @@ class StoreTests: QuickSpec {
             
             it("should not deadlock when reading the store during a read operation") {
                 let result = sut.filter(User.self, isIncluded: { (_) -> Bool in
-                    let _ = sut.findAll(User.self)
+                    _ = sut.findAll(User.self)
                     return true
                 })
                 
@@ -415,7 +415,7 @@ class StoreTests: QuickSpec {
             
             it("should not deadlock when synchronously reading the store from another queue during a reading operation") {
                 let result = sut.filter(User.self, isIncluded: { (_) -> Bool in
-                    let _ = queue.sync {
+                    _ = queue.sync {
                         sut.findAll(User.self)
                     }
                     return true
@@ -426,7 +426,7 @@ class StoreTests: QuickSpec {
             
             it("should not deadlock when reading the store during a write operation") {
                 let user = sut.insert { (id) -> User in
-                    let _ = sut.findAll(User.self)
+                    _ = sut.findAll(User.self)
                     return User(id: id, store: sut)
                 }
                 expect(user).toEventuallyNot(beNil())
@@ -434,7 +434,7 @@ class StoreTests: QuickSpec {
             
             it("should not deadlock when synchronously reading the store from another queue during a write operation") {
                 let user = sut.insert { (id) -> User in
-                    let _ = queue.sync {
+                    _ = queue.sync {
                         sut.findAll(User.self)
                     }
                     return User(id: id, store: sut)

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -334,8 +334,8 @@ class StoreTests: QuickSpec {
             
             it("should be able to concurrently delete objects") {
                 let users = sut.create(User.self, number: 100)
-                DispatchQueue.concurrentPerform(iterations: 100) { (i) in
-                    try! sut.delete(users[i])
+                DispatchQueue.concurrentPerform(iterations: 100) { (index) in
+                    try! sut.delete(users[index])
                 }
                 expect(sut.findAll(User.self).count).to(equal(0))
             }
@@ -343,9 +343,9 @@ class StoreTests: QuickSpec {
             it("should be able to concurrently update and delete objects") {
                 let users = sut.create(User.self, number: 100)
                 
-                DispatchQueue.concurrentPerform(iterations: 100) { (i) in
-                    try! sut.update(users[i])
-                    try! sut.delete(users[i])
+                DispatchQueue.concurrentPerform(iterations: 100) { (index) in
+                    try! sut.update(users[index])
+                    try! sut.delete(users[index])
                 }
                 expect(sut.findAll(User.self)).to(beEmpty())
             }


### PR DESCRIPTION
Building Kakapo after adding it as a Carthage dependency I got some errors from SwiftLint regarding some variable's name length.

Four of them I added as exceptions in the SwiftLint config file, the other was just an index variable.